### PR TITLE
Bump fastapi to >=0.136.3 to fix PYSEC-2026-161

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ snowflake = [
 starrocks = ["pymysql"]
 trino = ["trino"]
 web = [
-    "fastapi==0.120.1",
+    "fastapi>=0.136.3",
     "watchfiles>=0.19.0",
     "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",
@@ -142,7 +142,7 @@ web = [
 ]
 lsp = [
     # Duplicate of web
-    "fastapi==0.120.1",
+    "fastapi>=0.136.3",
     "watchfiles>=0.19.0",
     # "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",


### PR DESCRIPTION
Bumps the FastAPI pin from `==0.120.1` to `>=0.136.3` in both the `web` and `lsp` extras to resolve the PYSEC-2026-161 security vulnerability.
The previous exact pin transitively pulled in starlette 0.49.3 which is  affected by GHSA-86qp-5c8j-p5mr (missing Host header validation).  FastAPI >=0.136.3 allows starlette 1.0.1+ which contains the fix.

Closes #5812