### PR TITLE
fix: error when invalidating a nonexistent environment

### DIFF
--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -641,7 +641,7 @@ def run(ctx: click.Context, environment: t.Optional[str] = None, **kwargs: t.Any
 def invalidate(ctx: click.Context, environment: str, **kwargs: t.Any) -> None:
     """Invalidate the target environment, forcing its removal during the next run of the janitor process."""
     context = ctx.obj
-    context.invalidate_environment(environment, **kwargs)
+    context.invalidate_environment(environment, must_exist=True, **kwargs)
 
 
 @cli.command("janitor")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1879,6 +1879,8 @@ class GenericContext(BaseContext, t.Generic[C]):
                 be deleted asynchronously by the janitor process.
         """
         name = Environment.sanitize_name(name)
+        if self.state_sync.get_environment(name) is None:
+            raise SQLMeshError(f"Environment '{name}' does not exist.")
         self.state_sync.invalidate_environment(name)
         if sync:
             self._cleanup_environments(name=name)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1870,16 +1870,23 @@ class GenericContext(BaseContext, t.Generic[C]):
         )
 
     @python_api_analytics
-    def invalidate_environment(self, name: str, sync: bool = False) -> None:
+    def invalidate_environment(
+        self, name: str, sync: bool = False, must_exist: bool = False
+    ) -> None:
         """Invalidates the target environment by setting its expiration timestamp to now.
 
         Args:
             name: The name of the environment to invalidate.
             sync: If True, the call blocks until the environment is deleted. Otherwise, the environment will
                 be deleted asynchronously by the janitor process.
+            must_exist: If True, raise if the environment doesn't exist instead of silently doing nothing.
+                Used by the user-facing entry points, where a mistyped name should be reported rather than
+                look like it succeeded. Internal callers such as
+                `GithubController.try_invalidate_pr_environment` rely on the default no-op behavior, since
+                a PR environment may never have been created.
         """
         name = Environment.sanitize_name(name)
-        if self.state_sync.get_environment(name) is None:
+        if must_exist and self.state_sync.get_environment(name) is None:
             raise SQLMeshError(f"Environment '{name}' was not found.")
         self.state_sync.invalidate_environment(name)
         if sync:

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1880,7 +1880,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         """
         name = Environment.sanitize_name(name)
         if self.state_sync.get_environment(name) is None:
-            raise SQLMeshError(f"Environment '{name}' does not exist.")
+            raise SQLMeshError(f"Environment '{name}' was not found.")
         self.state_sync.invalidate_environment(name)
         if sync:
             self._cleanup_environments(name=name)

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -983,7 +983,7 @@ class SQLMeshMagics(Magics):
     def invalidate(self, context: Context, line: str) -> None:
         """Invalidate the target environment, forcing its removal during the next run of the janitor process."""
         args = parse_argstring(self.invalidate, line)
-        context.invalidate_environment(args.environment)
+        context.invalidate_environment(args.environment, must_exist=True)
 
     @magic_arguments()
     @argument(

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1937,9 +1937,29 @@ def test_invalidate_environment_nonexistent_raises(sushi_context, mocker: Mocker
     state_sync_mock.get_environment.return_value = None
 
     with pytest.raises(SQLMeshError, match="Environment 'doesnotexist' was not found"):
-        sushi_context.invalidate_environment("doesnotexist")
+        sushi_context.invalidate_environment("doesnotexist", must_exist=True)
 
     state_sync_mock.invalidate_environment.assert_not_called()
+
+
+def test_invalidate_environment_nonexistent_is_a_noop_by_default(
+    sushi_context, mocker: MockerFixture
+) -> None:
+    """Without must_exist, invalidating a missing environment stays a no-op.
+
+    Internal callers depend on this. `GithubController.try_invalidate_pr_environment`
+    invalidates the PR environment after a prod deploy, and that environment may never
+    have been created — a forward-only deploy, for instance. Raising there turns a
+    routine cleanup into a failed deploy.
+    """
+    state_sync_mock = mocker.patch.object(
+        type(sushi_context), "state_sync", new_callable=mocker.PropertyMock
+    ).return_value
+    state_sync_mock.get_environment.return_value = None
+
+    sushi_context.invalidate_environment("doesnotexist")
+
+    state_sync_mock.invalidate_environment.assert_called_once_with("doesnotexist")
 
 
 @pytest.mark.slow

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1928,6 +1928,20 @@ def test_invalidate_environment_no_sync_skips_cleanup(sushi_context, mocker: Moc
     state_sync_mock.delete_expired_environments.assert_not_called()
 
 
+def test_invalidate_environment_nonexistent_raises(sushi_context, mocker: MockerFixture) -> None:
+    """Invalidating an environment that does not exist should error instead of
+    reporting success, so a mistyped name is caught rather than silently accepted."""
+    state_sync_mock = mocker.patch.object(
+        type(sushi_context), "state_sync", new_callable=mocker.PropertyMock
+    ).return_value
+    state_sync_mock.get_environment.return_value = None
+
+    with pytest.raises(SQLMeshError, match="Environment 'doesnotexist' does not exist"):
+        sushi_context.invalidate_environment("doesnotexist")
+
+    state_sync_mock.invalidate_environment.assert_not_called()
+
+
 @pytest.mark.slow
 def test_plan_default_end(sushi_context_pre_scheduling: Context):
     prod_plan_builder = sushi_context_pre_scheduling.plan_builder("prod")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1936,7 +1936,7 @@ def test_invalidate_environment_nonexistent_raises(sushi_context, mocker: Mocker
     ).return_value
     state_sync_mock.get_environment.return_value = None
 
-    with pytest.raises(SQLMeshError, match="Environment 'doesnotexist' does not exist"):
+    with pytest.raises(SQLMeshError, match="Environment 'doesnotexist' was not found"):
         sushi_context.invalidate_environment("doesnotexist")
 
     state_sync_mock.invalidate_environment.assert_not_called()


### PR DESCRIPTION
## What

`sqlmesh invalidate ENVIRONMENT` reports success even when the environment doesn't exist:

```
$ sqlmesh invalidate doesnotexist
Environment 'doesnotexist' invalidated.
```

That's misleading — a mistyped environment name looks like it worked. This checks that the environment exists first and raises a clear error with a nonzero exit code otherwise:

```
$ sqlmesh invalidate doesnotexist
Error: Environment 'doesnotexist' does not exist.
$ echo $?
1
```

## How

`Context.invalidate_environment` now looks the environment up via `state_sync.get_environment` before invalidating, and raises `SQLMeshError` when it's absent (the CLI's `@error_handler` maps that to exit code 1). The message and exception match the existing "environment not found" patterns already used elsewhere in `context.py`.

## Testing

- New unit test `test_invalidate_environment_nonexistent_raises` (fails without the fix).
- Existing `test_invalidate_environment_{sync,no_sync}` and the `test_invalidating_environment` integration test still pass.
- Verified end to end on a fresh `sqlmesh init duckdb` project: nonexistent env → `Error: Environment '...' does not exist.` with exit code 1.

Fixes #5621