### PR TITLE
fix(migrations): keep still-live dev intervals in v0071

### DIFF
--- a/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
+++ b/sqlmesh/migrations/v0071_add_dev_version_to_intervals.py
@@ -106,7 +106,7 @@ def _migrate_intervals(
             continue
 
         dev_version = snapshot_ids_to_dev_versions.get((name, identifier))
-        if dev_version not in used_dev_versions and is_dev:
+        if (name, dev_version) not in used_dev_versions and is_dev:
             # If the interval's dev version is no longer used and this is a dev interval, we can safely delete it
             continue
 

--- a/tests/core/state_sync/test_state_sync.py
+++ b/tests/core/state_sync/test_state_sync.py
@@ -2937,6 +2937,141 @@ def test_migrate_rows(state_sync: EngineAdapterStateSync, mocker: MockerFixture)
     )
 
 
+def test_migrate_v0071_keeps_still_live_dev_intervals() -> None:
+    from sqlmesh.migrations import v0071_add_dev_version_to_intervals as migration
+
+    engine_adapter = create_engine_adapter(duckdb.connect, "duckdb")
+    engine_adapter.create_schema(c.SQLMESH)
+
+    engine_adapter.create_table(
+        "sqlmesh._snapshots",
+        {
+            "name": exp.DataType.build("text"),
+            "identifier": exp.DataType.build("text"),
+            "version": exp.DataType.build("text"),
+            "snapshot": exp.DataType.build("text"),
+            "kind_name": exp.DataType.build("text"),
+            "updated_ts": exp.DataType.build("bigint"),
+            "unpaused_ts": exp.DataType.build("bigint"),
+            "ttl_ms": exp.DataType.build("bigint"),
+            "unrestorable": exp.DataType.build("boolean"),
+        },
+    )
+    # The intervals table at schema version 70, before v0071 adds the dev_version column.
+    engine_adapter.create_table(
+        "sqlmesh._intervals",
+        {
+            "id": exp.DataType.build("text"),
+            "created_ts": exp.DataType.build("bigint"),
+            "name": exp.DataType.build("text"),
+            "identifier": exp.DataType.build("text"),
+            "version": exp.DataType.build("text"),
+            "start_ts": exp.DataType.build("bigint"),
+            "end_ts": exp.DataType.build("bigint"),
+            "is_dev": exp.DataType.build("boolean"),
+            "is_removed": exp.DataType.build("boolean"),
+            "is_compacted": exp.DataType.build("boolean"),
+            "is_pending_restatement": exp.DataType.build("boolean"),
+        },
+    )
+
+    def snapshot_blob(name: str, identifier: str, version: str, dev_version: str) -> str:
+        return json.dumps(
+            {
+                "name": name,
+                "identifier": identifier,
+                "version": version,
+                "dev_version": dev_version,
+                "fingerprint": {
+                    "data_hash": "data",
+                    "metadata_hash": "metadata",
+                    "parent_data_hash": "parent_data",
+                    "parent_metadata_hash": "parent_metadata",
+                },
+                "previous_versions": [],
+            }
+        )
+
+    engine_adapter.insert_append(
+        "sqlmesh._snapshots",
+        pd.DataFrame(
+            [
+                {
+                    "name": '"db"."prod_model"',
+                    "identifier": "prod_ident",
+                    "version": "prod_ver",
+                    "snapshot": snapshot_blob(
+                        '"db"."prod_model"', "prod_ident", "prod_ver", "prod_dev"
+                    ),
+                    "kind_name": "FULL",
+                    "updated_ts": 1,
+                    "unpaused_ts": None,
+                    "ttl_ms": None,
+                    "unrestorable": False,
+                },
+                {
+                    "name": '"db"."dev_model"',
+                    "identifier": "dev_ident",
+                    "version": "dev_ver",
+                    "snapshot": snapshot_blob(
+                        '"db"."dev_model"', "dev_ident", "dev_ver", "dev_dev"
+                    ),
+                    "kind_name": "FULL",
+                    "updated_ts": 1,
+                    "unpaused_ts": None,
+                    "ttl_ms": None,
+                    "unrestorable": False,
+                },
+            ]
+        ),
+    )
+
+    engine_adapter.insert_append(
+        "sqlmesh._intervals",
+        pd.DataFrame(
+            [
+                # A non-dev interval that is always kept; it forces the migration to
+                # rewrite the intervals table so a wrongly-dropped dev interval is
+                # actually deleted rather than left behind by the empty-result guard.
+                {
+                    "id": "prod_int",
+                    "created_ts": 1,
+                    "name": '"db"."prod_model"',
+                    "identifier": "prod_ident",
+                    "version": "prod_ver",
+                    "start_ts": 100,
+                    "end_ts": 200,
+                    "is_dev": False,
+                    "is_removed": False,
+                    "is_compacted": False,
+                    "is_pending_restatement": False,
+                },
+                # A dev interval whose version and dev version are both still live.
+                # It must be preserved by the migration.
+                {
+                    "id": "dev_int",
+                    "created_ts": 1,
+                    "name": '"db"."dev_model"',
+                    "identifier": "dev_ident",
+                    "version": "dev_ver",
+                    "start_ts": 100,
+                    "end_ts": 200,
+                    "is_dev": True,
+                    "is_removed": False,
+                    "is_compacted": False,
+                    "is_pending_restatement": False,
+                },
+            ]
+        ),
+    )
+
+    migration.migrate_schemas(engine_adapter, c.SQLMESH)
+    migration.migrate_rows(engine_adapter, c.SQLMESH)
+
+    surviving_ids = {row[0] for row in engine_adapter.fetchall("SELECT id FROM sqlmesh._intervals")}
+    assert surviving_ids == {"prod_int", "dev_int"}
+
+
 def test_backup_state(state_sync: EngineAdapterStateSync, mocker: MockerFixture) -> None:
     state_sync.engine_adapter.replace_query(
         "sqlmesh._snapshots",


### PR DESCRIPTION
**Note:** This only helps installs that have **not** already run v0071. Users who already migrated still have the dropped intervals and need a re-backfill / manual repair. There is no recovery path in this PR.

The v0071 intervals migration drops every still-live dev interval on upgrade
because of a type mismatch in a set-membership check.

In `_migrate_intervals`, `used_dev_versions` is a `Set[Tuple[str, str]]` and its
only insertion adds a `(name, dev_version)` 2-tuple:

```python
used_dev_versions.add((name, dev_version))
```

But the guard that decides whether to drop a dev interval compares a bare
`dev_version` string against that set:

```python
dev_version = snapshot_ids_to_dev_versions.get((name, identifier))
if dev_version not in used_dev_versions and is_dev:
    # If the interval's dev version is no longer used and this is a dev interval, we can safely delete it
    continue
```

A `str` is never an element of a set of 2-tuples, so `dev_version not in
used_dev_versions` is always `True` and the condition collapses to
`if is_dev: continue`. Every dev interval that had already passed the preceding
`used_versions` check (i.e. is still live) is discarded, forcing a re-backfill of
dev environments after the upgrade.

This changes the check to compare the correctly-typed `(name, dev_version)` key,
matching the tuples stored in `used_dev_versions`, so only genuinely unused dev
intervals are removed.

## Test Plan

- Added `test_migrate_v0071_keeps_still_live_dev_intervals` in
  `tests/core/state_sync/test_state_sync.py`. It builds an in-memory DuckDB state
  at schema v70 (intervals table without the `dev_version` column) with a live
  prod snapshot/interval and a live dev snapshot/interval, runs the v0071
  `migrate_schemas` + `migrate_rows`, and asserts both intervals survive.
- Confirmed the test fails without the fix (the dev interval is dropped:
  `{'prod_int'} != {'dev_int', 'prod_int'}`) and passes with it.
- Also confirmed a genuinely-stale dev interval (its dev version no longer mapped
  to a live snapshot) is still correctly removed, so the fix is not over-broad.
- `make style` (ruff + ruff-format + mypy) passes on the changed files; the
  `tests/core/state_sync/test_state_sync.py` migration/interval subset passes.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
