### PR TITLE
fix(plan): add explainer visit method for PhysicalLayerSchemaCreationStage

### DIFF
--- a/sqlmesh/core/plan/explainer.py
+++ b/sqlmesh/core/plan/explainer.py
@@ -8,9 +8,11 @@ from collections import defaultdict
 
 from rich.console import Console as RichConsole
 from rich.tree import Tree
+from sqlglot import exp
 from sqlglot.dialects.dialect import DialectType
 from sqlmesh.core import constants as c
 from sqlmesh.core.console import Console, TerminalConsole, get_console
+from sqlmesh.core.dialect import schema_
 from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.plan.common import (
     SnapshotIntervalClearRequest,
@@ -144,6 +146,29 @@ class RichExplainerConsole(ExplainerConsole):
 
     def visit_after_all_stage(self, stage: stages.AfterAllStage) -> Tree:
         return Tree("[bold]Execute after all statements[/bold]")
+
+    def visit_physical_layer_schema_creation_stage(
+        self, stage: stages.PhysicalLayerSchemaCreationStage
+    ) -> t.Optional[Tree]:
+        tables = [
+            exp.to_table(
+                snapshot.table_name(is_deployable=stage.deployability_index.is_deployable(snapshot))
+            )
+            for snapshot in stage.snapshots
+            if snapshot.is_model and not snapshot.is_symbolic
+        ]
+        schemas = {
+            schema_(table.args["db"], table.args.get("catalog")).sql(dialect=self.dialect)
+            for table in tables
+            if table.db
+        }
+        if not schemas:
+            return None
+
+        tree = Tree("[bold]Create physical schemas if they do not exist[/bold]")
+        for schema in sorted(schemas):
+            tree.add(schema)
+        return tree
 
     def visit_physical_layer_update_stage(self, stage: stages.PhysicalLayerUpdateStage) -> Tree:
         snapshots = [

--- a/tests/core/integration/test_plan_options.py
+++ b/tests/core/integration/test_plan_options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import typing as t
 import pytest
 from sqlmesh.core.console import (
@@ -112,7 +113,7 @@ def test_empty_backfill_new_model(init_and_plan_context: t.Callable):
 
 
 @time_machine.travel("2023-01-08 15:00:00 UTC")
-def test_plan_explain(init_and_plan_context: t.Callable):
+def test_plan_explain(init_and_plan_context: t.Callable, caplog):
     old_console = get_console()
     set_console(TerminalConsole())
 
@@ -131,15 +132,19 @@ def test_plan_explain(init_and_plan_context: t.Callable):
     common_kwargs = dict(skip_tests=True, no_prompts=True, explain=True)
 
     # For now just making sure the plan doesn't error
-    context.plan("dev", **common_kwargs)
-    context.plan("dev", **common_kwargs, skip_backfill=True)
-    context.plan("dev", **common_kwargs, empty_backfill=True)
-    context.plan("dev", **common_kwargs, forward_only=True, enable_preview=True)
-    context.plan("prod", **common_kwargs)
-    context.plan("prod", **common_kwargs, forward_only=True)
-    context.plan("prod", **common_kwargs, restate_models=[waiter_revenue_by_day_model.name])
+    with caplog.at_level(logging.ERROR, logger="sqlmesh.core.plan.explainer"):
+        context.plan("dev", **common_kwargs)
+        context.plan("dev", **common_kwargs, skip_backfill=True)
+        context.plan("dev", **common_kwargs, empty_backfill=True)
+        context.plan("dev", **common_kwargs, forward_only=True, enable_preview=True)
+        context.plan("prod", **common_kwargs)
+        context.plan("prod", **common_kwargs, forward_only=True)
+        context.plan("prod", **common_kwargs, restate_models=[waiter_revenue_by_day_model.name])
 
     set_console(old_console)
+
+    # Every stage produced by the plan must have a corresponding visit method on the explainer
+    assert "Unexpected stage" not in caplog.text
 
     # Make sure that the now changes were actually applied
     for target_env in ("dev", "prod"):


### PR DESCRIPTION
Fixes #5619

## Problem

`RichExplainerConsole` has no `visit_physical_layer_schema_creation_stage`, so when a plan contains `PhysicalLayerSchemaCreationStage`, `explain()` falls into the `hasattr` guard at [`explainer.py:134`](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/plan/explainer.py#L134):

```
sqlmesh.core.plan.explainer - ERROR - Unexpected stage: PhysicalLayerSchemaCreationStage
```

The stage is then silently dropped from the explained plan, even though `PlanEvaluator` handles it in [`evaluator.py:209`](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/plan/evaluator.py#L209).

## Change

Add the missing visit method. It mirrors the schema derivation in `SnapshotEvaluator.create_physical_schemas` / `_create_schemas` — non-symbolic models only, table name resolved through the stage's deployability index, deduplicated by `(db, catalog)` — and lists the distinct physical schemas that will be created. Returns `None` when there is nothing to create, consistent with the other `Optional[Tree]` visit methods.

Placed directly before `visit_physical_layer_update_stage` to match the stage ordering produced in `stages.py`.

Output on `examples/sushi`:

```
├── Create physical schemas if they do not exist
│   └── memory.sqlmesh__sushi
├── Backfill models by running their queries and run standalone audits
│   ├── sushi.waiter_revenue_by_day -> ...
```

## Tests

`test_plan_explain` previously only asserted that explaining does not raise, which is why this went unnoticed. It now asserts that no stage is reported as unexpected, which covers this stage and guards against the same omission for stages added later.

Verified the test fails on `main` with the fix reverted:

```
E  AssertionError: assert 'Unexpected stage' not in '...'
E    'Unexpected stage' is contained here:
E      er.py:134 Unexpected stage: PhysicalLayerSchemaCreationStage
```

`tests/core/test_plan.py`, `tests/core/test_plan_stages.py`, `tests/core/test_context.py` and `tests/core/integration/test_plan_options.py` pass (207 tests), as do `ruff format`, `ruff check` and `mypy` on the changed files.