### PR TITLE
TSC change: replace Reid Hooper with Cortland Goffena on the TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Initial TSC voting members are the project's Maintainers:
 |---------------------|---------------|----------------|------------| 
 | Alexander Butler    | z3z1ma        | Harness        | TSC Member |
 | Alexander Filipchik | afilipchik    | Cloud Kitchens | TSC Member |
-| Reid Hooper         | rhooper9711   | Benzinga       | TSC Member |
+| Cortland Goffena    | cmgoffena13   | Benzinga       | TSC Member |
 | Yuki Kakegawa       | StuffbyYuki   | Jump.ai        | TSC Member |
 | Toby Mao            | tobymao       | Fivetran       | TSC Chair  |
 | Alex Wilde          | alexminerv    | Minerva        | TSC Member |


### PR DESCRIPTION
## Summary
- Update the Technical Steering Committee membership in `CONTRIBUTING.md`
- Replace Reid Hooper (`rhooper9711`) with Cortland Goffena (`cmgoffena13`) as the Benzinga TSC member

## Test plan
- [ ] Confirm the TSC table in `CONTRIBUTING.md` lists Cortland Goffena with the correct GitHub handle and affiliation