### PR TITLE
docs: fix doubled words and a misspelling in the docs

### DIFF
--- a/docs/concepts/macros/sqlmesh_macros.md
+++ b/docs/concepts/macros/sqlmesh_macros.md
@@ -1608,7 +1608,7 @@ def add_args(
     return argument_1 + argument_2 + argument_3
 ```
 
-An `@add_args` call providing values for all arguments accepts positional arguments like this: `@add_args(5, 6, 7)` (which returns 5 + 6 + 7 = `18`). A call omitting and using the default value for the the final `argument_3` can also use positional arguments: `@add_args(5, 6)` (which returns 5 + 6 + 3 = `14`).
+An `@add_args` call providing values for all arguments accepts positional arguments like this: `@add_args(5, 6, 7)` (which returns 5 + 6 + 7 = `18`). A call omitting and using the default value for the final `argument_3` can also use positional arguments: `@add_args(5, 6)` (which returns 5 + 6 + 3 = `14`).
 
 However, skipping an argument requires specifying the names of subsequent arguments (i.e., using "keyword arguments"). For example, skipping the second argument above by just omitting it - `@add_args(5, , 7)` - results in an error.
 

--- a/docs/concepts/models/model_kinds.md
+++ b/docs/concepts/models/model_kinds.md
@@ -583,7 +583,7 @@ MODEL (
 
 ### When Matched Expression
 
-The logic to use when updating columns when a match occurs (the source and target match on the given keys) by default updates all the columns. This can be overriden with custom logic like below:
+The logic to use when updating columns when a match occurs (the source and target match on the given keys) by default updates all the columns. This can be overridden with custom logic like below:
 
 ```sql linenums="1" hl_lines="5"
 MODEL (
@@ -1437,7 +1437,7 @@ GROUP BY
 
 SCD Type 2 models are designed by default to protect the data that has been captured because it is not possible to recreate the history once it has been lost.
 However, there are cases where you may want to clear the history and start fresh.
-For this use use case you will want to start by setting `disable_restatement` to `false` in the model definition.
+For this use case you will want to start by setting `disable_restatement` to `false` in the model definition.
 
 ```sql linenums="1" hl_lines="5"
 MODEL (

--- a/docs/guides/ui.md
+++ b/docs/guides/ui.md
@@ -225,7 +225,7 @@ You may include all a project's models by clicking `All` in the Show drop-down o
 
 ![Lineage module - all models](./ui/ui-guide_lineage-all.png){ loading=lazy }
 
-Click `Connected` in the Show drop-down menu to highlight edges between upstream parents and downstream children in blue. This may be helpful when when a project contains many models:
+Click `Connected` in the Show drop-down menu to highlight edges between upstream parents and downstream children in blue. This may be helpful when a project contains many models:
 
 ![Lineage module - all models, connected edges](./ui/ui-guide_lineage-all-connected.png){ loading=lazy }
 

--- a/docs/quickstart/notebook.md
+++ b/docs/quickstart/notebook.md
@@ -248,7 +248,7 @@ You've now created a new production environment with all of history backfilled.
 
 ## 3. Update a model
 
-Now that we have have populated the `prod` environment, let's modify one of the SQL models.
+Now that we have populated the `prod` environment, let's modify one of the SQL models.
 
 We can modify the incremental SQL model using the `%model` *line* notebook magic (note the single `%`) and the model name:
 


### PR DESCRIPTION
A few small typos in the documentation prose:

- `docs/concepts/models/model_kinds.md`: "This can be overriden" -> "overridden"; and "For this use use case" -> "For this use case".
- `docs/concepts/macros/sqlmesh_macros.md`: "the default value for the the final `argument_3`" -> "for the final".
- `docs/guides/ui.md`: "This may be helpful when when a project" -> "when a project".
- `docs/quickstart/notebook.md`: "Now that we have have populated" -> "we have populated".

Documentation only.
