### PR TITLE
fix: raise ValueError for an out-of-range epoch in to_datetime

### DIFF
--- a/sqlmesh/utils/date.py
+++ b/sqlmesh/utils/date.py
@@ -194,7 +194,13 @@ def to_datetime(
             try:
                 dt = datetime.strptime(str(value), DATE_INT_FMT)
             except ValueError:
-                dt = datetime.fromtimestamp(epoch / 1000.0, tz=UTC)
+                try:
+                    dt = datetime.fromtimestamp(epoch / 1000.0, tz=UTC)
+                except (OverflowError, OSError, ValueError):
+                    # A non-finite or out-of-range epoch (e.g. "inf", 1e30, or a
+                    # huge millis value) overflows fromtimestamp. Fall through to
+                    # the ValueError below rather than leaking OverflowError/OSError.
+                    dt = None
 
     if dt is None:
         raise ValueError(f"Could not convert `{value}` to datetime.")

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -42,6 +42,17 @@ def test_to_datetime() -> None:
 
 
 @pytest.mark.parametrize(
+    "value",
+    ["inf", "-inf", "1e30", "99999999999999999999", float("inf")],
+)
+def test_to_datetime_out_of_range_raises(value: t.Any) -> None:
+    # A non-finite or out-of-range epoch overflows fromtimestamp; it must raise
+    # the documented ValueError rather than leaking OverflowError/OSError.
+    with pytest.raises(ValueError):
+        to_datetime(value)
+
+
+@pytest.mark.parametrize(
     "expression, result",
     [
         ("1 second ago", datetime(2023, 1, 20, 12, 29, 59, tzinfo=UTC)),


### PR DESCRIPTION
`to_datetime` (and therefore `to_timestamp`/`to_date`) leaks `OverflowError`/`OSError` on a number-like value that is out of range, instead of the `ValueError` it documents:

```python
from sqlmesh.utils.date import to_datetime

to_datetime("inf")                    # OverflowError: timestamp out of range for platform time_t
to_datetime("1e30")                   # OverflowError
to_datetime("99999999999999999999")  # OSError: [Errno 22] Invalid argument
```

In the number branch, the value passes `float()` (`float("inf")` and large floats do not raise), `strptime` fails, and `datetime.fromtimestamp(epoch / 1000.0)` then overflows. Only `ValueError` was expected there, so `OverflowError`/`OSError` escape. The docstring states *'Raises: ValueError if value cannot be converted to a datetime'*, and `"nan"` already raises `ValueError` via the same path, so this makes the out-of-range cases consistent.

The fix catches `OverflowError`/`OSError`/`ValueError` around `fromtimestamp` and falls through to the existing `raise ValueError(...)`. Added a parametrized regression test in `tests/utils/test_date.py`.