### PR TITLE
Fix stale IntervalUnit docstring to match enum members

### DIFF
--- a/sqlmesh/core/node.py
+++ b/sqlmesh/core/node.py
@@ -28,7 +28,8 @@ if t.TYPE_CHECKING:
 class IntervalUnit(str, Enum):
     """IntervalUnit is the inferred granularity of an incremental node.
 
-    IntervalUnit can be one of 5 types, YEAR, MONTH, DAY, HOUR, MINUTE. The unit is inferred
+    IntervalUnit can be one of 7 types: YEAR, MONTH, DAY, HOUR, HALF_HOUR, QUARTER_HOUR,
+    FIVE_MINUTE. The unit is inferred
     based on the cron schedule of a node. The minimum time delta between a sample set of dates
     is used to determine which unit a node's schedule is.
 


### PR DESCRIPTION
The `IntervalUnit` class docstring in `sqlmesh/core/node.py` is out of date with the enum defined directly below it. It states:

> IntervalUnit can be one of 5 types, YEAR, MONTH, DAY, HOUR, MINUTE.

But the enum actually has 7 members and no `MINUTE`: `YEAR`, `MONTH`, `DAY`, `HOUR`, `HALF_HOUR`, `QUARTER_HOUR`, `FIVE_MINUTE`. The sub-hour granularities were added after the docstring was written. This updates the docstring to match the code (and the public `model_configuration` docs, which already list all seven values).

Documentation-only; no behavior change.