### PR TITLE
Bump fastapi to >=0.136.3 and starlette to >=1.01 for Python >= 3.10 to fix PYSEC-2026-161

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,10 @@ snowflake = [
 starrocks = ["pymysql"]
 trino = ["trino"]
 web = [
-    "fastapi==0.120.1",
+    # fastapi>=0.136.3 brings in starlette>=1.0.1, which fixes PYSEC-2026-161.
+    # Both require Python >= 3.10, so 3.9 stays on the previous pin.
+    "fastapi>=0.136.3; python_version >= '3.10'",
+    "fastapi==0.120.1; python_version < '3.10'",
     "watchfiles>=0.19.0",
     "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",
@@ -142,7 +145,8 @@ web = [
 ]
 lsp = [
     # Duplicate of web
-    "fastapi==0.120.1",
+    "fastapi>=0.136.3; python_version >= '3.10'",
+    "fastapi==0.120.1; python_version < '3.10'",
     "watchfiles>=0.19.0",
     # "uvicorn[standard]==0.22.0",
     "sse-starlette>=0.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,8 @@ snowflake = [
 starrocks = ["pymysql"]
 trino = ["trino"]
 web = [
-    # fastapi>=0.136.3 brings in starlette>=1.0.1, which fixes PYSEC-2026-161.
-    # Both require Python >= 3.10, so 3.9 stays on the previous pin.
     "fastapi>=0.136.3; python_version >= '3.10'",
+    "starlette>=1.0.1; python_version >= '3.10'",
     "fastapi==0.120.1; python_version < '3.10'",
     "watchfiles>=0.19.0",
     "uvicorn[standard]==0.22.0",
@@ -146,6 +145,7 @@ web = [
 lsp = [
     # Duplicate of web
     "fastapi>=0.136.3; python_version >= '3.10'",
+    "starlette>=1.0.1; python_version >= '3.10'",
     "fastapi==0.120.1; python_version < '3.10'",
     "watchfiles>=0.19.0",
     # "uvicorn[standard]==0.22.0",

--- a/web/server/settings.py
+++ b/web/server/settings.py
@@ -96,7 +96,7 @@ def get_path_to_model_mapping(
 
 def get_loaded_context(
     settings: Settings = Depends(get_settings),
-) -> t.Generator[Context, None]:
+) -> t.Generator[Context, None, None]:
     try:
         with get_loaded_context_lock:
             yield _get_loaded_context(settings.project_path, settings.config, settings.gateway)


### PR DESCRIPTION
## Description

Closes https://github.com/SQLMesh/sqlmesh/issues/5812

This is a redo of https://github.com/SQLMesh/sqlmesh/pull/5838 hopefully with CI issues fixed.

Starlette 1.01 doesn't support Python <3.10 so we can only upgrade for certain python versions.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
