### PR TITLE
fix(model): keep quoting when normalizing column_descriptions keys

### DIFF
--- a/sqlmesh/core/model/meta.py
+++ b/sqlmesh/core/model/meta.py
@@ -321,16 +321,18 @@ class ModelMeta(_Node):
         if isinstance(vs, (exp.Tuple, exp.Array)):
             vs = vs.expressions
 
-        raw_col_descriptions = (
-            vs
+        # Normalize each part while it is still an identifier, so that a quoted
+        # column keeps its case on dialects where quoting makes it significant.
+        col_descriptions = (
+            {normalize_identifiers(k, dialect=dialect).name: v for k, v in vs.items()}
             if isinstance(vs, dict)
-            else {".".join([part.this for part in v.this.parts]): v.expression.name for v in vs}
+            else {
+                ".".join(
+                    normalize_identifiers(part, dialect=dialect).name for part in v.this.parts
+                ): v.expression.name
+                for v in vs
+            }
         )
-
-        col_descriptions = {
-            normalize_identifiers(k, dialect=dialect).name: v
-            for k, v in raw_col_descriptions.items()
-        }
 
         columns_to_types = data.get("columns_to_types_")
         if columns_to_types:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1026,6 +1026,49 @@ def test_column_descriptions_quoted_identifier():
     assert set(model.column_descriptions) <= set(model.columns_to_types)
 
 
+def test_column_descriptions_dotted_identifier():
+    # A nested field is looked up by its dotted path, so every part normalizes on its own.
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind FULL,
+            dialect bigquery,
+            column_descriptions (
+                record.`myField` = 'a nested field'
+            )
+        );
+
+        SELECT STRUCT(1 AS `myField`) AS record
+    """
+    )
+    model = load_sql_based_model(expressions, dialect="bigquery")
+
+    assert model.column_descriptions == {"record.myfield": "a nested field"}
+
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind FULL,
+            dialect snowflake,
+            column_descriptions (
+                nested.field = 'an unquoted path',
+                "MyStruct"."myField" = 'a quoted path'
+            )
+        );
+
+        SELECT 1 AS c
+    """
+    )
+    model = load_sql_based_model(expressions, dialect="snowflake")
+
+    assert model.column_descriptions == {
+        "NESTED.FIELD": "an unquoted path",
+        "MyStruct.myField": "a quoted path",
+    }
+
+
 def test_model_jinja_macro_reference_extraction():
     @macro()
     def test_macro(**kwargs) -> None:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1000,6 +1000,32 @@ def test_column_descriptions(sushi_context, assert_exp_eq):
     assert model.column_descriptions == {"id": "primary key", "foo": "bar"}
 
 
+def test_column_descriptions_quoted_identifier():
+    expressions = d.parse(
+        """
+        MODEL (
+            name db.table,
+            kind FULL,
+            dialect snowflake,
+            column_descriptions (
+                "myColumn" = 'a case-sensitive column',
+                other_column = 'an unquoted column'
+            )
+        );
+
+        SELECT 1 AS "myColumn", 2 AS other_column
+    """
+    )
+    model = load_sql_based_model(expressions, dialect="snowflake")
+
+    # A quoted key keeps its case, an unquoted one is still normalized.
+    assert model.column_descriptions == {
+        "myColumn": "a case-sensitive column",
+        "OTHER_COLUMN": "an unquoted column",
+    }
+    assert set(model.column_descriptions) <= set(model.columns_to_types)
+
+
 def test_model_jinja_macro_reference_extraction():
     @macro()
     def test_macro(**kwargs) -> None:


### PR DESCRIPTION
Fixes #5943.

`_column_descriptions_validator` builds each key with `".".join(part.this for part in v.this.parts)`. `part.this` is the bare identifier string, so the `quoted` flag is gone before `normalize_identifiers` runs, and the key is normalized as if it had never been quoted. On a dialect where quoting makes a column case-sensitive, `"myColumn"` becomes `MYCOLUMN`, matches no column, and gets dropped along with the rest of the table's comments.

Normalizing each part while it is still an identifier fixes it. Unquoted keys normalize exactly as before, and the dict branch used by Python models is unchanged in behaviour.

Before, with `dialect snowflake`:

```
descriptions: {'MYCOLUMN': 'comment for a case-sensitive column'}
columns     : ['myColumn']
```

After: `{'myColumn': ...}`.

`test_column_descriptions_quoted_identifier` covers both halves, a quoted key keeping its case and an unquoted one still normalizing, and fails on main with `MYCOLUMN != myColumn`.

`tests/core/test_model.py` passes in full (334). `ruff` and `ruff-format` pass. `mypy` on the changed module reports nothing.
