### PR TITLE
fix: open files read-only during format --check

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1338,7 +1338,8 @@ class GenericContext(BaseContext, t.Generic[C]):
             ):  # introduced to satisfy type checker as still want to pull filter out as many targets as possible before loop
                 continue
 
-            with open(target._path, "r+", encoding="utf-8") as file:
+            mode = "r" if check else "r+"
+            with open(target._path, mode, encoding="utf-8") as file:
                 before = file.read()
 
                 after = self._format(

--- a/tests/core/test_format.py
+++ b/tests/core/test_format.py
@@ -1,4 +1,6 @@
+import os
 import pathlib
+import stat
 
 from pytest_mock.plugin import MockerFixture
 from sqlmesh.core.config import Config
@@ -144,6 +146,25 @@ def test_ignore_formating_files(tmp_path: pathlib.Path):
         model3.read_text(encoding="utf-8")
         == "MODEL (\n  name this.model3,\n  dialect 'duckdb',\n  formatting TRUE\n);\n\nSELECT\n  1 AS col"
     )
+
+
+def test_format_check_read_only_files(tmp_path: pathlib.Path, mocker: MockerFixture):
+    models_dir = pathlib.Path("models")
+
+    model_text = "MODEL(name this.model, dialect 'duckdb'); SELECT 1 AS col"
+    model = create_temp_file(
+        tmp_path,
+        pathlib.Path(models_dir, "model.sql"),
+        model_text,
+    )
+    os.chmod(model, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+
+    context = Context(paths=tmp_path, config=Config())
+    context.console = mocker.Mock()
+    context.load()
+
+    assert not context.format(check=True)
+    assert model.read_text(encoding="utf-8") == model_text
 
 
 def test_format_without_state_load(tmp_path: pathlib.Path, mocker: MockerFixture):


### PR DESCRIPTION
## Description

`sqlmesh format --check` opened model/audit SQL files with `r+` even though check mode only reads them. That requires write permission and can fail on read-only filesystems in certain CI setups.

This change opens files in `r` mode when `check=True`, and keeps `r+` for normal format runs that write back to disk.

## Test Plan

- [x] Added `test_format_check_read_only_files` — chmods a model file to read-only and verifies `format(check=True)` completes without error, reports the file needs reformatting, and leaves the file unchanged
- [x] `make style` passes
- [x] `make fast-test` passes

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)