### PR TITLE
fix(makefile): exclude web install for dbt 1.6 to fix test

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -514,7 +514,12 @@ jobs:
             echo "DBT version is ${{ matrix.dbt-version }} (>= 1.6.0), keeping semantic_models and metrics sections"
           fi
 
-          make dbt-fast-test
+          # dbt 1.6 installs without web/lsp (pydantic conflict); skip collecting those tests
+          if [[ "${{ matrix.dbt-version }}" == "1.6" ]]; then
+            pytest -n auto -m "dbt and fast" --reruns 3 --ignore=tests/lsp --ignore=tests/web
+          else
+            make dbt-fast-test
+          fi
       - name: Test SQLMesh info in sushi_dbt
         working-directory: ./examples/sushi_dbt
         run: |

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,12 @@ install-dev-dbt-%:
 		echo "Applying numpy<2 constraint for dbt $$version"; \
 		$(SED_INPLACE) 's/"numpy"/"numpy<2"/g' pyproject.toml; \
 	fi; \
-	$(MAKE) install-dev; \
+	if [ "$$version" = "1.6.0" ]; then \
+		echo "Installing without web/lsp for dbt 1.6.0 (fastapi>=0.136 needs pydantic v2; dbt 1.6 needs pydantic v1)"; \
+		$(PIP) install -e ".[dev,slack,dlt]" ./examples/custom_materializations; \
+	else \
+		$(MAKE) install-dev; \
+	fi; \
 	if [ "$$version" = "1.6.0" ]; then \
 		echo "Applying overrides for dbt 1.6.0"; \
 		$(PIP) install 'pydantic>=2.0.0' 'google-cloud-bigquery==3.30.0' 'databricks-sdk==0.28.0' \


### PR DESCRIPTION
## Description

Remove web/lsp install on test. New upgrade in fastapi version >=0.136.3 requires pydantic>=2.9.0 and the old 1.6 dbt version requires pydantic < 2. 

## Test Plan

Test Plan is getting stage `test-dbt-versions (1.6)` to work.

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
