### PR TITLE
feature: adding smarter unit test execution

### DIFF
--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -52,7 +52,7 @@ Bad data is worse than no data. The best way to keep bad data out of your system
 ### [Tests](./tests.md)
 SQLMesh "tests" are similar to unit tests in software development, where the unit is a single model. SQLMesh tests validate model *code* &mdash; you specify the input data and expected output, then SQLMesh runs the test and compares the expected and actual output.
 
-SQLMesh automatically runs tests for models included in a `plan` (added, modified, or restated). Plans with no such models skip unit tests by default. Use `--all-tests` for the full suite, `--skip-tests` to skip, or run tests on demand with the [`test` command](../reference/cli.md#test).
+SQLMesh automatically runs all unit tests when a `plan` is created. Use `--test-changed-only` to run tests only for models included in the plan (added, modified, or restated), `--skip-tests` to skip, run tests for specific models with [`sqlmesh test --select-model`](../reference/cli.md#test), or run the full suite on demand with the [`test` command](../reference/cli.md#test).
 
 Learn more in the [testing guide](../guides/testing.md).
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -52,7 +52,7 @@ Bad data is worse than no data. The best way to keep bad data out of your system
 ### [Tests](./tests.md)
 SQLMesh "tests" are similar to unit tests in software development, where the unit is a single model. SQLMesh tests validate model *code* &mdash; you specify the input data and expected output, then SQLMesh runs the test and compares the expected and actual output.
 
-SQLMesh automatically runs tests for models included in a `plan` (added, modified, or restated). Plans with no such models, and `--skip-backfill` / `--dry-run` plans, skip unit tests by default. Use `--all-tests` for the full suite, `--skip-tests` to skip, or run tests on demand with the [`test` command](../reference/cli.md#test).
+SQLMesh automatically runs tests for models included in a `plan` (added, modified, or restated). Plans with no such models skip unit tests by default. Use `--all-tests` for the full suite, `--skip-tests` to skip, or run tests on demand with the [`test` command](../reference/cli.md#test).
 
 Learn more in the [testing guide](../guides/testing.md).
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -52,7 +52,9 @@ Bad data is worse than no data. The best way to keep bad data out of your system
 ### [Tests](./tests.md)
 SQLMesh "tests" are similar to unit tests in software development, where the unit is a single model. SQLMesh tests validate model *code* &mdash; you specify the input data and expected output, then SQLMesh runs the test and compares the expected and actual output.
 
-SQLMesh automatically runs tests when you apply a `plan`, or you can run them on demand with the [`test` command](../reference/cli.md#test).
+SQLMesh automatically runs tests for models included in a `plan` (added, modified, or restated). Plans with no such models, and `--skip-backfill` / `--dry-run` plans, skip unit tests by default. Use `--all-tests` for the full suite, `--skip-tests` to skip, or run tests on demand with the [`test` command](../reference/cli.md#test).
+
+Learn more in the [testing guide](../guides/testing.md).
 
 ### [Audits](./audits.md)
 In contrast to tests, SQLMesh "audits" validate the results of model code applied to your actual data.

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -4,10 +4,6 @@ Testing allows you to protect your project from regression by continuously verif
 
 By default, `sqlmesh plan` runs unit tests only for models included in the plan (added, modified, or restated). Plans with no such models skip unit tests. Use `--all-tests` to run the full suite, or `--skip-tests` to run none.
 
-!!! important
-
-    `--skip-backfill` / `--dry-run` plans skip unit tests by default. Pass `--all-tests` if you still want the full suite to run.
-
 Similar to unit testing in software development, SQLMesh evaluates the model's logic against predefined inputs and then compares the output to expected outcomes provided as part of each test.
 
 A comprehensive suite of tests can empower data practitioners to work with confidence, as it allows them to ensure models behave as expected after changes have been applied to them.

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -1,6 +1,12 @@
 # Testing
 
-Testing allows you to protect your project from regression by continuously verifying that the output of each model matches your expectations. Unlike [audits](audits.md), tests are executed either on demand (for example, as part of a CI/CD job) or every time a new [plan](plans.md) is created.
+Testing allows you to protect your project from regression by continuously verifying that the output of each model matches your expectations. Unlike [audits](audits.md), tests are executed either on demand (for example, as part of a CI/CD job or via [`sqlmesh test`](../reference/cli.md#test)) or when a new [plan](plans.md) is created.
+
+By default, `sqlmesh plan` runs unit tests only for models included in the plan (added, modified, or restated). Plans with no such models skip unit tests. Use `--all-tests` to run the full suite, or `--skip-tests` to run none.
+
+!!! important
+
+    `--skip-backfill` / `--dry-run` plans skip unit tests by default. Pass `--all-tests` if you still want the full suite to run.
 
 Similar to unit testing in software development, SQLMesh evaluates the model's logic against predefined inputs and then compares the output to expected outcomes provided as part of each test.
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -2,7 +2,7 @@
 
 Testing allows you to protect your project from regression by continuously verifying that the output of each model matches your expectations. Unlike [audits](audits.md), tests are executed either on demand (for example, as part of a CI/CD job or via [`sqlmesh test`](../reference/cli.md#test)) or when a new [plan](plans.md) is created.
 
-By default, `sqlmesh plan` runs unit tests only for models included in the plan (added, modified, or restated). Plans with no such models skip unit tests. Use `--all-tests` to run the full suite, or `--skip-tests` to run none.
+By default, `sqlmesh plan` runs all unit tests. Use `--test-changed-only` to run tests only for models included in the plan (added, modified, or restated), or `--skip-tests` to run none. With both `--select-model` and `--test-changed-only`, tests run only for selected models that changed.
 
 Similar to unit testing in software development, SQLMesh evaluates the model's logic against predefined inputs and then compares the output to expected outcomes provided as part of each test.
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -66,7 +66,7 @@
 
     However, the commands to create and apply a plan are different. In Terraform, the "plan" command generates a plan and saves it to file. The "apply" command reads a plan file and applies it.
 
-    In SQLMesh, the `sqlmesh plan` command generates a plan, runs any unit tests, and prompts the user to apply the plan. There is no "apply" command in SQLMesh.
+    In SQLMesh, the `sqlmesh plan` command generates a plan, runs unit tests for models included in the plan, and prompts the user to apply the plan. There is no "apply" command in SQLMesh.
 
 ## Getting Started
 
@@ -102,7 +102,7 @@
     SQLMesh's default behavior is appropriate for most deployments, but you can override where SQLMesh creates physical tables and views with [schema configuration options](../guides/configuration.md#environment-schemas).
 
 ??? question "What's the difference between a `test` and an `audit`?"
-    A SQLMesh [`test`](../concepts/tests.md) is analogous to a "unit test" in software engineering. It tests *code* based on known inputs and outputs. In SQLMesh, the inputs and outputs are specified in a YAML file, and SQLMesh automatically runs them when `sqlmesh plan` is executed.
+    A SQLMesh [`test`](../concepts/tests.md) is analogous to a "unit test" in software engineering. It tests *code* based on known inputs and outputs. In SQLMesh, the inputs and outputs are specified in a YAML file, and SQLMesh runs tests for models included in the plan when `sqlmesh plan` is executed (use `--all-tests` for the full suite).
 
     Writing YAML is annoying and error-prone, so SQLMesh's [`create_test` command](../concepts/tests.md#automatic-test-generation) allows you to automatically generate YAML test files based on queries of existing data tables.
 
@@ -126,7 +126,7 @@
 ??? question "What's the difference between `sqlmesh plan` and `sqlmesh run`?"
     During project development, there are two things in play: the current state of your project files and the existing states of each environment you have.
 
-    SQLMesh’s `plan` command is the primary tool for understanding the effects of changes you make to your project. If your project files have changed or are different from the state of an environment, you execute `sqlmesh plan [environment name]` to synchronize the environment's state with your project files. `sqlmesh plan` will generate a summary of the actions needed to implement the changes, automatically run unit tests, and prompt you to `apply` the plan and implement the changes.
+    SQLMesh’s `plan` command is the primary tool for understanding the effects of changes you make to your project. If your project files have changed or are different from the state of an environment, you execute `sqlmesh plan [environment name]` to synchronize the environment's state with your project files. `sqlmesh plan` will generate a summary of the actions needed to implement the changes, run unit tests for models included in the plan, and prompt you to `apply` the plan and implement the changes.
 
     If your project files have not changed, you execute `sqlmesh run` to run your project's models and audits.
 
@@ -210,7 +210,7 @@
     - Configure your project and set up a project database (using DuckDB locally or a database connection)
     - Create, configure, and modify models, audits, tests, and other project components
     - Execute `sqlmesh plan [environment name]` to:
-        - Generate a summary of the differences between your project files and the environment and whether each change is `breaking`. The `plan` includes a list of the actions needed to implement the changes and automatically runs the project's unit `test`s.
+        - Generate a summary of the differences between your project files and the environment and whether each change is `breaking`. The `plan` includes a list of the actions needed to implement the changes and runs unit `test`s for models included in the plan.
         - Optionally apply the plan to implement the actions and run the project's `audit`s.
     - Execute `sqlmesh run` on a schedule to ingest and transform new data
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -102,7 +102,7 @@
     SQLMesh's default behavior is appropriate for most deployments, but you can override where SQLMesh creates physical tables and views with [schema configuration options](../guides/configuration.md#environment-schemas).
 
 ??? question "What's the difference between a `test` and an `audit`?"
-    A SQLMesh [`test`](../concepts/tests.md) is analogous to a "unit test" in software engineering. It tests *code* based on known inputs and outputs. In SQLMesh, the inputs and outputs are specified in a YAML file, and SQLMesh runs tests for models included in the plan when `sqlmesh plan` is executed (use `--all-tests` for the full suite).
+    A SQLMesh [`test`](../concepts/tests.md) is analogous to a "unit test" in software engineering. It tests *code* based on known inputs and outputs. In SQLMesh, the inputs and outputs are specified in a YAML file, and SQLMesh runs all unit tests when `sqlmesh plan` is executed (use `--test-changed-only` to run only tests for models in the plan).
 
     Writing YAML is annoying and error-prone, so SQLMesh's [`create_test` command](../concepts/tests.md#automatic-test-generation) allows you to automatically generate YAML test files based on queries of existing data tables.
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -66,7 +66,7 @@
 
     However, the commands to create and apply a plan are different. In Terraform, the "plan" command generates a plan and saves it to file. The "apply" command reads a plan file and applies it.
 
-    In SQLMesh, the `sqlmesh plan` command generates a plan, runs unit tests for models included in the plan, and prompts the user to apply the plan. There is no "apply" command in SQLMesh.
+    In SQLMesh, the `sqlmesh plan` command generates a plan, runs any unit tests, and prompts the user to apply the plan. There is no "apply" command in SQLMesh.
 
 ## Getting Started
 
@@ -126,7 +126,7 @@
 ??? question "What's the difference between `sqlmesh plan` and `sqlmesh run`?"
     During project development, there are two things in play: the current state of your project files and the existing states of each environment you have.
 
-    SQLMesh’s `plan` command is the primary tool for understanding the effects of changes you make to your project. If your project files have changed or are different from the state of an environment, you execute `sqlmesh plan [environment name]` to synchronize the environment's state with your project files. `sqlmesh plan` will generate a summary of the actions needed to implement the changes, run unit tests for models included in the plan, and prompt you to `apply` the plan and implement the changes.
+    SQLMesh’s `plan` command is the primary tool for understanding the effects of changes you make to your project. If your project files have changed or are different from the state of an environment, you execute `sqlmesh plan [environment name]` to synchronize the environment's state with your project files. `sqlmesh plan` will generate a summary of the actions needed to implement the changes, automatically run unit tests, and prompt you to `apply` the plan and implement the changes.
 
     If your project files have not changed, you execute `sqlmesh run` to run your project's models and audits.
 
@@ -210,7 +210,7 @@
     - Configure your project and set up a project database (using DuckDB locally or a database connection)
     - Create, configure, and modify models, audits, tests, and other project components
     - Execute `sqlmesh plan [environment name]` to:
-        - Generate a summary of the differences between your project files and the environment and whether each change is `breaking`. The `plan` includes a list of the actions needed to implement the changes and runs unit `test`s for models included in the plan.
+        - Generate a summary of the differences between your project files and the environment and whether each change is `breaking`. The `plan` includes a list of the actions needed to implement the changes and automatically runs the project's unit `test`s.
         - Optionally apply the plan to implement the actions and run the project's `audit`s.
     - Execute `sqlmesh run` on a schedule to ingest and transform new data
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -162,10 +162,6 @@ Reverting to a previous model version is a quick operation since no additional w
 SQLMesh automatically validates your models in order to ensure the quality and accuracy of your data. This is done via the following:
 
 * Running unit tests for models in the plan when you execute the `plan` command (use `--all-tests` for the full suite, or `--skip-tests` to skip). This ensures changes applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
-
-    !!! important
-
-        `--skip-backfill` / `--dry-run` plans skip unit tests by default. Pass `--all-tests` if you still want tests to run.
 * Running audits whenever data is loaded to a table (either for backfill or loading on a cadence). This way you know all data present in any table has passed all defined audits. Refer to [auditing](../concepts/audits.md) for more information.
 
 SQLMesh also provides automatic validation via CI/CD by automatically creating a preview environment.

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -161,7 +161,11 @@ Reverting to a previous model version is a quick operation since no additional w
 
 SQLMesh automatically validates your models in order to ensure the quality and accuracy of your data. This is done via the following:
 
-* Running unit tests by default when you execute the `plan` command. This ensures all changes to applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
+* Running unit tests for models in the plan when you execute the `plan` command (use `--all-tests` for the full suite, or `--skip-tests` to skip). This ensures changes applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
+
+    !!! important
+
+        `--skip-backfill` / `--dry-run` plans skip unit tests by default. Pass `--all-tests` if you still want tests to run.
 * Running audits whenever data is loaded to a table (either for backfill or loading on a cadence). This way you know all data present in any table has passed all defined audits. Refer to [auditing](../concepts/audits.md) for more information.
 
 SQLMesh also provides automatic validation via CI/CD by automatically creating a preview environment.

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -161,7 +161,7 @@ Reverting to a previous model version is a quick operation since no additional w
 
 SQLMesh automatically validates your models in order to ensure the quality and accuracy of your data. This is done via the following:
 
-* Running all unit tests when you execute the `plan` command (use `--test-changed-only` to run only tests for models in the plan, or `--skip-tests` to skip). This ensures changes applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
+* Running all unit tests when you execute the `plan` command (use `--test-changed-only` to run only tests for models in the plan). This ensures changes applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
 * Running audits whenever data is loaded to a table (either for backfill or loading on a cadence). This way you know all data present in any table has passed all defined audits. Refer to [auditing](../concepts/audits.md) for more information.
 
 SQLMesh also provides automatic validation via CI/CD by automatically creating a preview environment.

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -161,7 +161,7 @@ Reverting to a previous model version is a quick operation since no additional w
 
 SQLMesh automatically validates your models in order to ensure the quality and accuracy of your data. This is done via the following:
 
-* Running unit tests for models in the plan when you execute the `plan` command (use `--all-tests` for the full suite, or `--skip-tests` to skip). This ensures changes applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
+* Running all unit tests when you execute the `plan` command (use `--test-changed-only` to run only tests for models in the plan, or `--skip-tests` to skip). This ensures changes applied to any environment are logically validated. Refer to [testing](../concepts/tests.md) for more information.
 * Running audits whenever data is loaded to a table (either for backfill or loading on a cadence). This way you know all data present in any table has passed all defined audits. Refer to [auditing](../concepts/audits.md) for more information.
 
 SQLMesh also provides automatic validation via CI/CD by automatically creating a preview environment.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -14,10 +14,6 @@ As the unit tests run, SQLMesh will identify any that fail.
 
 By default, `sqlmesh plan` runs unit tests only for models included in the plan (added, modified, or restated). Plans with no such models skip unit tests. Use `--all-tests` to run the full suite, or `--skip-tests` to run none.
 
-!!! important
-
-    `--skip-backfill` / `--dry-run` plans skip unit tests by default. Pass `--all-tests` if you still want the full suite to run.
-
 For more information about tests, refer to [testing](../concepts/tests.md).
 
 ### Test changes to a specific model

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -12,13 +12,19 @@ OK
 ```
 As the unit tests run, SQLMesh will identify any that fail.
 
-By default, `sqlmesh plan` runs unit tests only for models included in the plan (added, modified, or restated). Plans with no such models skip unit tests. Use `--all-tests` to run the full suite, or `--skip-tests` to run none.
+By default, `sqlmesh plan` runs all unit tests. Use `--test-changed-only` to run tests only for models included in the plan (added, modified, or restated), or `--skip-tests` to run none. With both `--select-model` and `--test-changed-only`, tests run only for selected models that changed.
 
 For more information about tests, refer to [testing](../concepts/tests.md).
 
 ### Test changes to a specific model
 
-To run a specific model test, pass in the suite file name followed by `::` and the name of the test; for example: `sqlmesh test tests/test_suite.yaml::test_example_full_model`.
+To run unit tests for a specific model, use `--select-model`:
+
+```bash
+$ sqlmesh test --select-model sqlmesh_example.full_model
+```
+
+Alternatively, pass in the suite file name followed by `::` and the name of the test; for example: `sqlmesh test tests/test_suite.yaml::test_example_full_model`.
 
 ### Run a subset of tests
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -12,6 +12,12 @@ OK
 ```
 As the unit tests run, SQLMesh will identify any that fail.
 
+By default, `sqlmesh plan` runs unit tests only for models included in the plan (added, modified, or restated). Plans with no such models skip unit tests. Use `--all-tests` to run the full suite, or `--skip-tests` to run none.
+
+!!! important
+
+    `--skip-backfill` / `--dry-run` plans skip unit tests by default. Pass `--all-tests` if you still want the full suite to run.
+
 For more information about tests, refer to [testing](../concepts/tests.md).
 
 ### Test changes to a specific model

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -357,8 +357,8 @@ Options:
                                   Default: prod.
   --skip-tests                    Skip tests prior to generating the plan if
                                   they are defined.
-  --all-tests                     Run all unit tests instead of only tests for
-                                  models included in the plan.
+  --test-changed-only             Run unit tests only for models included in
+                                  the plan instead of all tests.
   --skip-linter                   Skip linting prior to generating the plan if
                                   the linter is enabled.
   -r, --restate-model TEXT        Restate data for specified models and models
@@ -628,6 +628,8 @@ Options:
   -v, --verbose        Verbose output.
   --preserve-fixtures  Preserve the fixture tables in the testing database,
                        useful for debugging.
+  --select-model TEXT  Select specific models to run unit tests for. Can be
+                       specified multiple times.
   --help               Show this message and exit.
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -357,6 +357,8 @@ Options:
                                   Default: prod.
   --skip-tests                    Skip tests prior to generating the plan if
                                   they are defined.
+  --all-tests                     Run all unit tests instead of only tests for
+                                  models included in the plan.
   --skip-linter                   Skip linting prior to generating the plan if
                                   the linter is enabled.
   -r, --restate-model TEXT        Restate data for specified models and models
@@ -371,7 +373,8 @@ Options:
                                   when comparing to existing snapshots for
                                   matching models in the target environment.
   --skip-backfill, --dry-run      Skip the backfill step and only create a
-                                  virtual update for the plan.
+                                  virtual update for the plan. Unit tests are
+                                  also skipped unless --all-tests is passed.
   --empty-backfill                Produce empty backfill. Like --skip-backfill
                                   no models will be backfilled, unlike --skip-
                                   backfill missing intervals will be recorded

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -373,8 +373,7 @@ Options:
                                   when comparing to existing snapshots for
                                   matching models in the target environment.
   --skip-backfill, --dry-run      Skip the backfill step and only create a
-                                  virtual update for the plan. Unit tests are
-                                  also skipped unless --all-tests is passed.
+                                  virtual update for the plan.
   --empty-backfill                Produce empty backfill. Like --skip-backfill
                                   no models will be backfilled, unlike --skip-
                                   backfill missing intervals will be recorded

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -96,7 +96,7 @@ options:
 #### plan
 ```
 %plan [--start START] [--end END] [--execution-time EXECUTION_TIME]
-            [--create-from CREATE_FROM] [--skip-tests] [--all-tests]
+            [--create-from CREATE_FROM] [--skip-tests] [--test-changed-only]
             [--restate-model [RESTATE_MODEL ...]] [--no-gaps]
             [--skip-backfill, --dry-run] [--forward-only]
             [--effective-from EFFECTIVE_FROM] [--no-prompts] [--auto-apply]
@@ -120,8 +120,8 @@ options:
                         The environment to create the target environment from
                         if it doesn't exist. Default: prod.
   --skip-tests, -t      Skip the unit tests defined for the model.
-  --all-tests           Run all unit tests instead of only tests for models
-                        included in the plan.
+  --test-changed-only   Run unit tests only for models included in the plan
+                        instead of all tests.
   --restate-model <[RESTATE_MODEL ...]>, -r <[RESTATE_MODEL ...]>
                         Restate data for specified models (and models
                         downstream from the one specified). For production
@@ -433,7 +433,8 @@ options:
 
 #### run_test
 ```
-%run_test [--pattern [PATTERN ...]] [--verbose] [--preserve-fixtures] [tests ...]
+%run_test [--pattern [PATTERN ...]] [--verbose] [--preserve-fixtures]
+          [--select-model [SELECT_MODEL ...]] [tests ...]
 
 Run unit test(s).
 
@@ -446,6 +447,8 @@ options:
   --verbose, -v         Verbose output.
   --preserve-fixtures   Preserve the fixture tables in the testing database,
                         useful for debugging.
+  --select-model <[SELECT_MODEL ...]>
+                        Select specific models to run unit tests for.
 ```
 
 #### audit

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -96,7 +96,7 @@ options:
 #### plan
 ```
 %plan [--start START] [--end END] [--execution-time EXECUTION_TIME]
-            [--create-from CREATE_FROM] [--skip-tests]
+            [--create-from CREATE_FROM] [--skip-tests] [--all-tests]
             [--restate-model [RESTATE_MODEL ...]] [--no-gaps]
             [--skip-backfill, --dry-run] [--forward-only]
             [--effective-from EFFECTIVE_FROM] [--no-prompts] [--auto-apply]
@@ -120,6 +120,8 @@ options:
                         The environment to create the target environment from
                         if it doesn't exist. Default: prod.
   --skip-tests, -t      Skip the unit tests defined for the model.
+  --all-tests           Run all unit tests instead of only tests for models
+                        included in the plan.
   --restate-model <[RESTATE_MODEL ...]>, -r <[RESTATE_MODEL ...]>
                         Restate data for specified models (and models
                         downstream from the one specified). For production
@@ -131,7 +133,9 @@ options:
                         comparing to existing snapshots for matching models in
                         the target environment.
   --skip-backfill, --dry-run
-                        Skip the backfill step and only create a virtual update for the plan.
+                        Skip the backfill step and only create a virtual
+                        update for the plan. Unit tests are also skipped
+                        unless --all-tests is passed.
   --forward-only        Create a plan for forward-only changes.
   --effective-from EFFECTIVE_FROM
                         The effective date from which to apply forward-only

--- a/docs/reference/notebook.md
+++ b/docs/reference/notebook.md
@@ -134,8 +134,7 @@ options:
                         the target environment.
   --skip-backfill, --dry-run
                         Skip the backfill step and only create a virtual
-                        update for the plan. Unit tests are also skipped
-                        unless --all-tests is passed.
+                        update for the plan.
   --forward-only        Create a plan for forward-only changes.
   --effective-from EFFECTIVE_FROM
                         The effective date from which to apply forward-only

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -424,6 +424,12 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     default=None,
 )
 @click.option(
+    "--all-tests",
+    is_flag=True,
+    help="Run all unit tests instead of only tests for models included in the plan.",
+    default=None,
+)
+@click.option(
     "--skip-linter",
     is_flag=True,
     help="Skip linting prior to generating the plan if the linter is enabled.",
@@ -446,7 +452,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     "--skip-backfill",
     "--dry-run",
     is_flag=True,
-    help="Skip the backfill step and only create a virtual update for the plan.",
+    help="Skip the backfill step and only create a virtual update for the plan. Unit tests are also skipped unless --all-tests is passed.",
     default=None,
 )
 @click.option(

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -452,7 +452,7 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     "--skip-backfill",
     "--dry-run",
     is_flag=True,
-    help="Skip the backfill step and only create a virtual update for the plan. Unit tests are also skipped unless --all-tests is passed.",
+    help="Skip the backfill step and only create a virtual update for the plan.",
     default=None,
 )
 @click.option(

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -424,9 +424,9 @@ def diff(ctx: click.Context, environment: t.Optional[str] = None) -> None:
     default=None,
 )
 @click.option(
-    "--all-tests",
+    "--test-changed-only",
     is_flag=True,
-    help="Run all unit tests instead of only tests for models included in the plan.",
+    help="Run unit tests only for models included in the plan instead of all tests.",
     default=None,
 )
 @click.option(
@@ -801,6 +801,12 @@ def create_test(
     default=False,
     help="Preserve the fixture tables in the testing database, useful for debugging.",
 )
+@click.option(
+    "--select-model",
+    type=str,
+    multiple=True,
+    help="Select specific models to run unit tests for.",
+)
 @click.argument("tests", nargs=-1)
 @click.pass_obj
 @error_handler
@@ -810,14 +816,19 @@ def test(
     k: t.List[str],
     verbose: int,
     preserve_fixtures: bool,
+    select_model: t.List[str],
     tests: t.List[str],
 ) -> None:
     """Run model unit tests."""
+    model_names = (
+        obj._new_selector().expand_model_selections(select_model) if select_model else None
+    )
     result = obj.test(
         match_patterns=k,
         tests=tests,
         verbosity=Verbosity(verbose),
         preserve_fixtures=preserve_fixtures,
+        model_names=model_names,
     )
     if not result.wasSuccessful():
         exit(1)

--- a/sqlmesh/cli/project_init.py
+++ b/sqlmesh/cli/project_init.py
@@ -229,7 +229,7 @@ SELECT
 FROM
   {seed_model_name}
 WHERE
-  event_date BETWEEN @start_ds AND @end_ds
+  event_date BETWEEN @start_date AND @end_date
   """
 
     sql_models[seed_model_name] = f"""MODEL (

--- a/sqlmesh/cli/project_init.py
+++ b/sqlmesh/cli/project_init.py
@@ -229,7 +229,7 @@ SELECT
 FROM
   {seed_model_name}
 WHERE
-  event_date BETWEEN @start_date AND @end_date
+  event_date BETWEEN @start_ds AND @end_ds
   """
 
     sql_models[seed_model_name] = f"""MODEL (
@@ -284,25 +284,6 @@ WHERE
         num_orders: 2
       - item_id: 2
         num_orders: 1
-  """
-
-    tests["test_incremental_model"] = f"""test_example_incremental_model:
-  model: {incremental_model_name}
-  vars:
-    start: 2020-01-01
-    end: 2020-01-02
-  inputs:
-    {seed_model_name}:
-      rows:
-      - id: 1
-        item_id: 1
-        event_date: 2020-01-01
-  outputs:
-    query:
-      rows:
-      - id: 1
-        item_id: 1
-        event_date: 2020-01-01
   """
 
     return ExampleObjects(

--- a/sqlmesh/cli/project_init.py
+++ b/sqlmesh/cli/project_init.py
@@ -286,6 +286,25 @@ WHERE
         num_orders: 1
   """
 
+    tests["test_incremental_model"] = f"""test_example_incremental_model:
+  model: {incremental_model_name}
+  vars:
+    start: 2020-01-01
+    end: 2020-01-02
+  inputs:
+    {seed_model_name}:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+  outputs:
+    query:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+  """
+
     return ExampleObjects(
         sql_models=sql_models,
         python_models=python_models,

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -2232,6 +2232,9 @@ class TerminalConsole(Console):
         message = (
             f"Ran {result.testsRun} tests against {target_dialect} in {result.duration} seconds."
         )
+        if result.tests_skipped:
+            message = f"{message}\nSkipped {result.tests_skipped} tests"
+
         if result.wasSuccessful():
             self._print("=" * divider_length)
             self._print(
@@ -3160,6 +3163,8 @@ class NotebookMagicConsole(TerminalConsole):
         message = (
             f"Ran {result.testsRun} tests against {target_dialect} in {result.duration} seconds."
         )
+        if result.tests_skipped:
+            message = f"{message}\nSkipped {result.tests_skipped} tests"
 
         if result.wasSuccessful():
             success_color = {"color": "#008000"}
@@ -3600,6 +3605,8 @@ class MarkdownConsole(CaptureTerminalConsole):
             return
 
         message = f"Ran `{result.testsRun}` Tests Against `{target_dialect}`"
+        if result.tests_skipped:
+            message = f"{message}\n**Skipped `{result.tests_skipped}` Tests**"
 
         if result.wasSuccessful():
             self._print(f"**Successfully {message}**\n\n")

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -115,6 +115,7 @@ from sqlmesh.core.test import (
     ModelTestMetadata,
     generate_test,
     run_tests,
+    filter_tests_by_model_names,
     filter_tests_by_patterns,
 )
 from sqlmesh.core.user import User
@@ -1347,6 +1348,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         execution_time: t.Optional[TimeLike] = None,
         create_from: t.Optional[str] = None,
         skip_tests: t.Optional[bool] = None,
+        all_tests: t.Optional[bool] = None,
         restate_models: t.Optional[t.Iterable[str]] = None,
         no_gaps: t.Optional[bool] = None,
         skip_backfill: t.Optional[bool] = None,
@@ -1384,6 +1386,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             create_from: The environment to create the target environment from if it
                 doesn't exist. If not specified, the "prod" environment will be used.
             skip_tests: Unit tests are run by default so this will skip them if enabled
+            all_tests: Run every loaded unit test instead of only tests for models in the plan
             restate_models: A list of either internal or external models, or tags, that need to be restated
                 for the given plan interval. If the target environment is a production environment,
                 ALL snapshots that depended on these upstream tables will have their intervals deleted
@@ -1430,6 +1433,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             execution_time=execution_time,
             create_from=create_from,
             skip_tests=skip_tests,
+            all_tests=all_tests,
             restate_models=restate_models,
             no_gaps=no_gaps,
             skip_backfill=skip_backfill,
@@ -1484,6 +1488,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         execution_time: t.Optional[TimeLike] = None,
         create_from: t.Optional[str] = None,
         skip_tests: t.Optional[bool] = None,
+        all_tests: t.Optional[bool] = None,
         restate_models: t.Optional[t.Iterable[str]] = None,
         no_gaps: t.Optional[bool] = None,
         skip_backfill: t.Optional[bool] = None,
@@ -1518,6 +1523,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             create_from: The environment to create the target environment from if it
                 doesn't exist. If not specified, the "prod" environment will be used.
             skip_tests: Unit tests are run by default so this will skip them if enabled
+            all_tests: Run every loaded unit test instead of only tests for models in the plan
             restate_models: A list of either internal or external models, or tags, that need to be restated
                 for the given plan interval. If the target environment is a production environment,
                 ALL snapshots that depended on these upstream tables will have their intervals deleted
@@ -1559,6 +1565,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             "execution_time": execution_time,
             "create_from": create_from,
             "skip_tests": skip_tests,
+            "all_tests": all_tests,
             "restate_models": list(restate_models) if restate_models is not None else None,
             "no_gaps": no_gaps,
             "skip_backfill": skip_backfill,
@@ -1588,6 +1595,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         }
 
         skip_tests = explain or skip_tests or False
+        all_tests = all_tests or False
+        if skip_tests and all_tests:
+            raise PlanError("Cannot combine --all-tests with --skip-tests.")
         no_gaps = no_gaps or False
         skip_backfill = skip_backfill or False
         empty_backfill = empty_backfill or False
@@ -1595,6 +1605,10 @@ class GenericContext(BaseContext, t.Generic[C]):
         diff_rendered = diff_rendered or False
         skip_linter = skip_linter or False
         min_intervals = min_intervals or 0
+
+        # Virtual-only plans (--skip-backfill / --dry-run) skip unit tests unless --all-tests.
+        if skip_backfill and not all_tests:
+            skip_tests = True
 
         environment = environment or self.config.default_target_environment
         environment = Environment.sanitize_name(environment)
@@ -1613,8 +1627,6 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         if not skip_linter:
             self.lint_models()
-
-        self._run_plan_tests(skip_tests=skip_tests)
 
         environment_ttl = (
             self.environment_ttl if environment not in self.pinned_environments else None
@@ -1697,6 +1709,15 @@ class GenericContext(BaseContext, t.Generic[C]):
             *context_diff.modified_snapshots,
             *[s.name for s in context_diff.added],
         }
+
+        self._run_plan_tests(
+            skip_tests=skip_tests,
+            all_tests=all_tests,
+            model_names={
+                *modified_model_names,
+                *(expanded_restate_models or set()),
+            },
+        )
 
         if (
             is_dev
@@ -2314,6 +2335,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         verbosity: Verbosity = Verbosity.DEFAULT,
         preserve_fixtures: bool = False,
         stream: t.Optional[t.TextIO] = None,
+        model_names: t.Optional[t.Collection[str]] = None,
     ) -> ModelTextTestResult:
         """Discover and run model tests"""
         if verbosity >= Verbosity.VERBOSE:
@@ -2321,7 +2343,7 @@ class GenericContext(BaseContext, t.Generic[C]):
 
             pd.set_option("display.max_columns", None)
 
-        test_meta = self.select_tests(tests=tests, patterns=match_patterns)
+        test_meta = self.select_tests(tests=tests, patterns=match_patterns, model_names=model_names)
 
         result = run_tests(
             model_test_metadata=test_meta,
@@ -2781,15 +2803,24 @@ class GenericContext(BaseContext, t.Generic[C]):
         result = self.test(stream=test_output_io, verbosity=verbosity)
         return result, test_output_io.getvalue()
 
-    def _run_plan_tests(self, skip_tests: bool = False) -> t.Optional[ModelTextTestResult]:
-        if not skip_tests:
-            result = self.test()
-            if not result.wasSuccessful():
-                raise PlanError(
-                    "Cannot generate plan due to failing test(s). Fix test(s) and run again."
-                )
-            return result
-        return None
+    def _run_plan_tests(
+        self,
+        skip_tests: bool = False,
+        all_tests: bool = False,
+        model_names: t.Optional[t.Collection[str]] = None,
+    ) -> t.Optional[ModelTextTestResult]:
+        if skip_tests:
+            return None
+
+        if not all_tests and model_names is not None and not model_names:
+            return None
+
+        result = self.test(model_names=None if all_tests else model_names)
+        if not result.wasSuccessful():
+            raise PlanError(
+                "Cannot generate plan due to failing test(s). Fix test(s) and run again."
+            )
+        return result
 
     def _warn_if_virtual_catalog_rematerialization(self, plan: "Plan") -> None:
         """Warn when ClickHouse models appear as new snapshots solely because a virtual catalog
@@ -3465,6 +3496,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         self,
         tests: t.Optional[t.List[str]] = None,
         patterns: t.Optional[t.List[str]] = None,
+        model_names: t.Optional[t.Collection[str]] = None,
     ) -> t.List[ModelTestMetadata]:
         """Filter pre-loaded test metadata based on tests and patterns."""
 
@@ -3487,6 +3519,14 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         if patterns:
             test_meta = filter_tests_by_patterns(test_meta, patterns)
+
+        if model_names is not None:
+            test_meta = filter_tests_by_model_names(
+                test_meta,
+                set(model_names),
+                default_catalog=self.default_catalog,
+                dialect=self.default_dialect,
+            )
 
         return test_meta
 

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1348,7 +1348,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         execution_time: t.Optional[TimeLike] = None,
         create_from: t.Optional[str] = None,
         skip_tests: t.Optional[bool] = None,
-        all_tests: t.Optional[bool] = None,
+        test_changed_only: t.Optional[bool] = None,
         restate_models: t.Optional[t.Iterable[str]] = None,
         no_gaps: t.Optional[bool] = None,
         skip_backfill: t.Optional[bool] = None,
@@ -1386,7 +1386,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             create_from: The environment to create the target environment from if it
                 doesn't exist. If not specified, the "prod" environment will be used.
             skip_tests: Unit tests are run by default so this will skip them if enabled
-            all_tests: Run every loaded unit test instead of only tests for models in the plan
+            test_changed_only: Run unit tests only for models included in the plan instead of all tests
             restate_models: A list of either internal or external models, or tags, that need to be restated
                 for the given plan interval. If the target environment is a production environment,
                 ALL snapshots that depended on these upstream tables will have their intervals deleted
@@ -1433,7 +1433,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             execution_time=execution_time,
             create_from=create_from,
             skip_tests=skip_tests,
-            all_tests=all_tests,
+            test_changed_only=test_changed_only,
             restate_models=restate_models,
             no_gaps=no_gaps,
             skip_backfill=skip_backfill,
@@ -1488,7 +1488,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         execution_time: t.Optional[TimeLike] = None,
         create_from: t.Optional[str] = None,
         skip_tests: t.Optional[bool] = None,
-        all_tests: t.Optional[bool] = None,
+        test_changed_only: t.Optional[bool] = None,
         restate_models: t.Optional[t.Iterable[str]] = None,
         no_gaps: t.Optional[bool] = None,
         skip_backfill: t.Optional[bool] = None,
@@ -1523,7 +1523,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             create_from: The environment to create the target environment from if it
                 doesn't exist. If not specified, the "prod" environment will be used.
             skip_tests: Unit tests are run by default so this will skip them if enabled
-            all_tests: Run every loaded unit test instead of only tests for models in the plan
+            test_changed_only: Run unit tests only for models included in the plan instead of all tests
             restate_models: A list of either internal or external models, or tags, that need to be restated
                 for the given plan interval. If the target environment is a production environment,
                 ALL snapshots that depended on these upstream tables will have their intervals deleted
@@ -1565,7 +1565,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             "execution_time": execution_time,
             "create_from": create_from,
             "skip_tests": skip_tests,
-            "all_tests": all_tests,
+            "test_changed_only": test_changed_only,
             "restate_models": list(restate_models) if restate_models is not None else None,
             "no_gaps": no_gaps,
             "skip_backfill": skip_backfill,
@@ -1595,9 +1595,11 @@ class GenericContext(BaseContext, t.Generic[C]):
         }
 
         skip_tests = explain or skip_tests or False
-        all_tests = all_tests or False
-        if skip_tests and all_tests:
-            raise PlanError("Cannot combine --all-tests with --skip-tests.")
+        test_changed_only = test_changed_only or False
+
+        if skip_tests and test_changed_only:
+            raise PlanError("Cannot combine --skip-tests with --test-changed-only.")
+
         no_gaps = no_gaps or False
         skip_backfill = skip_backfill or False
         empty_backfill = empty_backfill or False
@@ -1706,13 +1708,17 @@ class GenericContext(BaseContext, t.Generic[C]):
             *[s.name for s in context_diff.added],
         }
 
+        plan_test_model_names: t.Set[str] = {
+            *modified_model_names,
+            *(expanded_restate_models or set()),
+        }
+        if select_models and test_changed_only:
+            plan_test_model_names &= selected_fqns
+
         self._run_plan_tests(
             skip_tests=skip_tests,
-            all_tests=all_tests,
-            model_names={
-                *modified_model_names,
-                *(expanded_restate_models or set()),
-            },
+            test_changed_only=test_changed_only,
+            model_names=plan_test_model_names,
         )
 
         if (
@@ -2339,7 +2345,15 @@ class GenericContext(BaseContext, t.Generic[C]):
 
             pd.set_option("display.max_columns", None)
 
-        test_meta = self.select_tests(tests=tests, patterns=match_patterns, model_names=model_names)
+        baseline_meta = self.select_tests(tests=tests, patterns=match_patterns, model_names=None)
+        if model_names is not None:
+            test_meta = self.select_tests(
+                tests=tests, patterns=match_patterns, model_names=model_names
+            )
+            tests_skipped = len(baseline_meta) - len(test_meta)
+        else:
+            test_meta = baseline_meta
+            tests_skipped = 0
 
         result = run_tests(
             model_test_metadata=test_meta,
@@ -2353,6 +2367,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             default_catalog=self.default_catalog,
             default_catalog_dialect=self.config.dialect or "",
         )
+        result.tests_skipped = tests_skipped
 
         self.console.log_test_results(
             result,
@@ -2802,16 +2817,20 @@ class GenericContext(BaseContext, t.Generic[C]):
     def _run_plan_tests(
         self,
         skip_tests: bool = False,
-        all_tests: bool = False,
+        test_changed_only: bool = False,
         model_names: t.Optional[t.Collection[str]] = None,
     ) -> t.Optional[ModelTextTestResult]:
         if skip_tests:
             return None
 
-        if not all_tests and model_names is not None and not model_names:
-            return None
+        effective_names: t.Optional[t.Set[str]] = None
 
-        result = self.test(model_names=None if all_tests else model_names)
+        if test_changed_only:
+            effective_names = set(model_names or [])
+            if not effective_names:
+                return None
+
+        result = self.test(model_names=effective_names)
         if not result.wasSuccessful():
             raise PlanError(
                 "Cannot generate plan due to failing test(s). Fix test(s) and run again."

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -1606,10 +1606,6 @@ class GenericContext(BaseContext, t.Generic[C]):
         skip_linter = skip_linter or False
         min_intervals = min_intervals or 0
 
-        # Virtual-only plans (--skip-backfill / --dry-run) skip unit tests unless --all-tests.
-        if skip_backfill and not all_tests:
-            skip_tests = True
-
         environment = environment or self.config.default_target_environment
         environment = Environment.sanitize_name(environment)
         is_dev = environment != c.PROD

--- a/sqlmesh/core/test/__init__.py
+++ b/sqlmesh/core/test/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlmesh.core.test.definition import ModelTest as ModelTest, generate_test as generate_test
 from sqlmesh.core.test.discovery import (
     ModelTestMetadata as ModelTestMetadata,
+    filter_tests_by_model_names as filter_tests_by_model_names,
     filter_tests_by_patterns as filter_tests_by_patterns,
 )
 from sqlmesh.core.test.result import ModelTextTestResult as ModelTextTestResult

--- a/sqlmesh/core/test/discovery.py
+++ b/sqlmesh/core/test/discovery.py
@@ -9,6 +9,7 @@ import ruamel
 
 from sqlmesh.utils import unique
 from sqlmesh.utils.pydantic import PydanticModel
+from sqlmesh.core.dialect import normalize_model_name
 
 
 class ModelTestMetadata(PydanticModel):
@@ -46,3 +47,35 @@ def filter_tests_by_patterns(
         if ("*" in pattern and fnmatch.fnmatchcase(test.fully_qualified_test_name, pattern))
         or pattern in test.fully_qualified_test_name
     )
+
+
+def filter_tests_by_model_names(
+    tests: list[ModelTestMetadata],
+    model_names: set[str],
+    *,
+    default_catalog: t.Optional[str] = None,
+    dialect: t.Optional[str] = None,
+) -> list[ModelTestMetadata]:
+    """Keep tests whose YAML ``model:`` resolves to one of the given model names.
+
+    Args:
+        tests: Loaded test metadata.
+        model_names: Model FQNs / names to keep (typically from a plan change set).
+        default_catalog: Catalog used when normalizing short model names.
+        dialect: Dialect used when normalizing model names.
+
+    Returns:
+        Tests that target a model in ``model_names``.
+    """
+
+    normalized_models = {
+        normalize_model_name(name, default_catalog=default_catalog, dialect=dialect)
+        for name in model_names
+    }
+    return [
+        test
+        for test in tests
+        if test.model_name
+        and normalize_model_name(test.model_name, default_catalog=default_catalog, dialect=dialect)
+        in normalized_models
+    ]

--- a/sqlmesh/core/test/result.py
+++ b/sqlmesh/core/test/result.py
@@ -15,6 +15,7 @@ if t.TYPE_CHECKING:
 
 class ModelTextTestResult(unittest.TextTestResult):
     successes: t.List[unittest.TestCase]
+    tests_skipped: int
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         self.console = kwargs.pop("console", None)
@@ -24,6 +25,7 @@ class ModelTextTestResult(unittest.TextTestResult):
         self.failure_tables: t.List[t.Tuple[t.Any, ...]] = []
         self.original_errors: t.List[t.Tuple[unittest.TestCase, ErrorType]] = []
         self.duration: t.Optional[float] = None
+        self.tests_skipped = 0
 
     def addSubTest(
         self,
@@ -123,6 +125,7 @@ class ModelTextTestResult(unittest.TextTestResult):
             self.addSkip(skipped_args[0], skipped_args[1])
 
         self.testsRun += other.testsRun
+        self.tests_skipped += other.tests_skipped
 
     def get_fail_and_error_tests(self) -> t.List[ModelTest]:
         # If tests contain failed subtests (e.g testing CTE outputs) we don't want

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -408,9 +408,9 @@ class SQLMeshMagics(Magics):
         help="Skip the unit tests defined for the model.",
     )
     @argument(
-        "--all-tests",
+        "--test-changed-only",
         action="store_true",
-        help="Run all unit tests instead of only tests for models included in the plan.",
+        help="Run unit tests only for models included in the plan instead of all tests.",
     )
     @argument(
         "--skip-linter",
@@ -538,7 +538,7 @@ class SQLMeshMagics(Magics):
             execution_time=args.execution_time,
             create_from=args.create_from,
             skip_tests=args.skip_tests,
-            all_tests=args.all_tests,
+            test_changed_only=args.test_changed_only,
             restate_models=args.restate_model,
             backfill_models=args.backfill_model,
             no_gaps=args.no_gaps,
@@ -1084,11 +1084,23 @@ class SQLMeshMagics(Magics):
         action="store_true",
         help="Preserve the fixture tables in the testing database, useful for debugging.",
     )
+    @argument(
+        "--select-model",
+        type=str,
+        nargs="*",
+        help="Select specific models to run unit tests for.",
+    )
     @line_magic
     @pass_sqlmesh_context
     def run_test(self, context: Context, line: str) -> None:
         """Run unit test(s)."""
         args = parse_argstring(self.run_test, line)
+
+        model_names = (
+            context._new_selector().expand_model_selections(args.select_model)
+            if args.select_model
+            else None
+        )
 
         context.test(
             match_patterns=args.pattern,
@@ -1096,6 +1108,7 @@ class SQLMeshMagics(Magics):
             verbosity=Verbosity(args.verbose),
             preserve_fixtures=args.preserve_fixtures,
             stream=StringIO(),  # consume the output instead of redirecting to stdout
+            model_names=model_names,
         )
 
     @magic_arguments()

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -408,6 +408,11 @@ class SQLMeshMagics(Magics):
         help="Skip the unit tests defined for the model.",
     )
     @argument(
+        "--all-tests",
+        action="store_true",
+        help="Run all unit tests instead of only tests for models included in the plan.",
+    )
+    @argument(
         "--skip-linter",
         action="store_true",
         help="Skip the linter for the model.",
@@ -429,7 +434,7 @@ class SQLMeshMagics(Magics):
         "--skip-backfill",
         "--dry-run",
         action="store_true",
-        help="Skip the backfill step and only create a virtual update for the plan.",
+        help="Skip the backfill step and only create a virtual update for the plan. Unit tests are also skipped unless --all-tests is passed.",
     )
     @argument(
         "--empty-backfill",
@@ -533,6 +538,7 @@ class SQLMeshMagics(Magics):
             execution_time=args.execution_time,
             create_from=args.create_from,
             skip_tests=args.skip_tests,
+            all_tests=args.all_tests,
             restate_models=args.restate_model,
             backfill_models=args.backfill_model,
             no_gaps=args.no_gaps,

--- a/sqlmesh/magics.py
+++ b/sqlmesh/magics.py
@@ -434,7 +434,7 @@ class SQLMeshMagics(Magics):
         "--skip-backfill",
         "--dry-run",
         action="store_true",
-        help="Skip the backfill step and only create a virtual update for the plan. Unit tests are also skipped unless --all-tests is passed.",
+        help="Skip the backfill step and only create a virtual update for the plan.",
     )
     @argument(
         "--empty-backfill",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -59,6 +59,31 @@ plan:
         )
 
 
+def add_unchanged_incremental_model_test(temp_dir) -> None:
+    with open(temp_dir / "tests" / "test_incremental_model.yaml", "w", encoding="utf-8") as f:
+        f.write(
+            """
+test_example_incremental_model:
+  model: sqlmesh_example.incremental_model
+  vars:
+    start: 2020-01-01
+    end: 2020-01-02
+  inputs:
+    sqlmesh_example.seed_model:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+  outputs:
+    query:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+"""
+        )
+
+
 def update_incremental_model(temp_dir) -> None:
     with open(temp_dir / "models" / "incremental_model.sql", "w", encoding="utf-8") as f:
         f.write(
@@ -117,7 +142,7 @@ def init_prod_and_backfill(runner, temp_dir) -> None:
 
 
 def assert_duckdb_test(result) -> None:
-    assert "Successfully Ran 2 tests against duckdb" in result.output
+    assert "Successfully Ran 1 tests against duckdb" in result.output
 
 
 def assert_new_env(result, new_env="prod", from_env="prod", initialize=True) -> None:
@@ -188,7 +213,7 @@ def test_plan_skip_tests(runner, tmp_path):
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--skip-tests"], input="y\n"
     )
     assert result.exit_code == 0
-    assert "Successfully Ran 2 tests against duckdb" not in result.output
+    assert "Successfully Ran 1 tests against duckdb" not in result.output
     assert_new_env(result)
     assert_backfill_success(result)
 
@@ -201,7 +226,7 @@ def test_plan_no_changes_runs_tests_by_default(runner, tmp_path):
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts"], input="\n"
     )
     assert result.exit_code == 0
-    assert "Successfully Ran 2 tests against duckdb" in result.output
+    assert "Successfully Ran 1 tests against duckdb" in result.output
     assert "No changes to plan" in result.output or "No changes" in result.output
 
 
@@ -229,6 +254,7 @@ def test_plan_test_changed_only_with_no_changes(runner, tmp_path):
 def test_plan_test_changed_only_runs_only_changed_model_tests(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
+    add_unchanged_incremental_model_test(tmp_path)
 
     full_model_path = tmp_path / "models" / "full_model.sql"
     full_model_path.write_text(
@@ -256,6 +282,7 @@ def test_plan_test_changed_only_runs_only_changed_model_tests(runner, tmp_path):
 def test_plan_select_model_test_changed_only_scopes_tests(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
+    add_unchanged_incremental_model_test(tmp_path)
 
     full_model_path = tmp_path / "models" / "full_model.sql"
     full_model_path.write_text(
@@ -263,7 +290,10 @@ def test_plan_select_model_test_changed_only_scopes_tests(runner, tmp_path):
     )
     incremental_model_path = tmp_path / "models" / "incremental_model.sql"
     incremental_model_path.write_text(
-        incremental_model_path.read_text().replace("'a' as new_col,", "'b' as new_col,")
+        incremental_model_path.read_text().replace(
+            "  item_id,\n  event_date,",
+            "  item_id,\n  'b' as new_col,\n  event_date,",
+        )
     )
 
     result = runner.invoke(
@@ -355,7 +385,7 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
     assert_virtual_layer_updated(result)
     assert "Model batches executed" not in result.output
     # Dry-run still runs plan-scoped unit tests
-    assert "Successfully Ran 2 tests against duckdb" in result.output
+    assert "Successfully Ran 1 tests against duckdb" in result.output
 
 
 def test_plan_min_intervals(runner, tmp_path):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -221,12 +221,13 @@ def test_plan_skip_tests(runner, tmp_path):
 def test_plan_no_changes_runs_tests_by_default(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
+    add_unchanged_incremental_model_test(tmp_path)
 
     result = runner.invoke(
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts"], input="\n"
     )
     assert result.exit_code == 0
-    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Successfully Ran 2 tests against duckdb" in result.output
     assert "No changes to plan" in result.output or "No changes" in result.output
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -219,6 +219,61 @@ def test_plan_all_tests_with_no_changes(runner, tmp_path):
     assert "Successfully Ran 1 tests against duckdb" in result.output
 
 
+def test_plan_runs_only_changed_model_tests(runner, tmp_path):
+    create_example_project(tmp_path)
+    init_prod_and_backfill(runner, tmp_path)
+
+    # Two unit tests total; changing full_model should run only its test
+    (tmp_path / "tests" / "test_incremental_model.yaml").write_text(
+        """test_example_incremental_model:
+  model: sqlmesh_example.incremental_model
+  vars:
+    start: 2020-01-01
+    end: 2020-01-02
+  inputs:
+    sqlmesh_example.seed_model:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+  outputs:
+    query:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+"""
+    )
+    full_model_path = tmp_path / "models" / "full_model.sql"
+    full_model_path.write_text(
+        full_model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)")
+    )
+
+    result = runner.invoke(
+        cli,
+        ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts", "--auto-apply"],
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Successfully Ran 2 tests against duckdb" not in result.output
+
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "plan",
+            "--all-tests",
+            "--no-prompts",
+        ],
+        input="\n",
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 2 tests against duckdb" in result.output
+
+
 def test_plan_skip_backfill_all_tests(runner, tmp_path):
     create_example_project(tmp_path)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -117,7 +117,7 @@ def init_prod_and_backfill(runner, temp_dir) -> None:
 
 
 def assert_duckdb_test(result) -> None:
-    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Successfully Ran 2 tests against duckdb" in result.output
 
 
 def assert_new_env(result, new_env="prod", from_env="prod", initialize=True) -> None:
@@ -188,74 +188,26 @@ def test_plan_skip_tests(runner, tmp_path):
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--skip-tests"], input="y\n"
     )
     assert result.exit_code == 0
-    assert "Successfully Ran 1 tests against duckdb" not in result.output
+    assert "Successfully Ran 2 tests against duckdb" not in result.output
     assert_new_env(result)
     assert_backfill_success(result)
 
 
-def test_plan_no_changes_skips_tests(runner, tmp_path):
+def test_plan_no_changes_runs_tests_by_default(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
 
-    # No model changes: unit tests should not run
     result = runner.invoke(
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts"], input="\n"
     )
     assert result.exit_code == 0
-    assert "Successfully Ran" not in result.output
+    assert "Successfully Ran 2 tests against duckdb" in result.output
     assert "No changes to plan" in result.output or "No changes" in result.output
 
 
-def test_plan_all_tests_with_no_changes(runner, tmp_path):
+def test_plan_test_changed_only_with_no_changes(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
-
-    result = runner.invoke(
-        cli,
-        ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--all-tests", "--no-prompts"],
-        input="\n",
-    )
-    assert result.exit_code == 0
-    assert "Successfully Ran 1 tests against duckdb" in result.output
-
-
-def test_plan_runs_only_changed_model_tests(runner, tmp_path):
-    create_example_project(tmp_path)
-    init_prod_and_backfill(runner, tmp_path)
-
-    # Two unit tests total; changing full_model should run only its test
-    (tmp_path / "tests" / "test_incremental_model.yaml").write_text(
-        """test_example_incremental_model:
-  model: sqlmesh_example.incremental_model
-  vars:
-    start: 2020-01-01
-    end: 2020-01-02
-  inputs:
-    sqlmesh_example.seed_model:
-      rows:
-      - id: 1
-        item_id: 1
-        event_date: 2020-01-01
-  outputs:
-    query:
-      rows:
-      - id: 1
-        item_id: 1
-        event_date: 2020-01-01
-"""
-    )
-    full_model_path = tmp_path / "models" / "full_model.sql"
-    full_model_path.write_text(
-        full_model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)")
-    )
-
-    result = runner.invoke(
-        cli,
-        ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts", "--auto-apply"],
-    )
-    assert result.exit_code == 0
-    assert "Successfully Ran 1 tests against duckdb" in result.output
-    assert "Successfully Ran 2 tests against duckdb" not in result.output
 
     result = runner.invoke(
         cli,
@@ -265,13 +217,94 @@ def test_plan_runs_only_changed_model_tests(runner, tmp_path):
             "--paths",
             tmp_path,
             "plan",
-            "--all-tests",
+            "--test-changed-only",
             "--no-prompts",
         ],
         input="\n",
     )
     assert result.exit_code == 0
-    assert "Successfully Ran 2 tests against duckdb" in result.output
+    assert "Successfully Ran" not in result.output
+
+
+def test_plan_test_changed_only_runs_only_changed_model_tests(runner, tmp_path):
+    create_example_project(tmp_path)
+    init_prod_and_backfill(runner, tmp_path)
+
+    full_model_path = tmp_path / "models" / "full_model.sql"
+    full_model_path.write_text(
+        full_model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)")
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "plan",
+            "--test-changed-only",
+            "--no-prompts",
+            "--auto-apply",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Skipped 1 tests" in result.output
+
+
+def test_plan_select_model_test_changed_only_scopes_tests(runner, tmp_path):
+    create_example_project(tmp_path)
+    init_prod_and_backfill(runner, tmp_path)
+
+    full_model_path = tmp_path / "models" / "full_model.sql"
+    full_model_path.write_text(
+        full_model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)")
+    )
+    incremental_model_path = tmp_path / "models" / "incremental_model.sql"
+    incremental_model_path.write_text(
+        incremental_model_path.read_text().replace("'a' as new_col,", "'b' as new_col,")
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "plan",
+            "--select-model",
+            "sqlmesh_example.full_model",
+            "--test-changed-only",
+            "--no-prompts",
+            "--auto-apply",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Skipped 1 tests" in result.output
+
+
+def test_test_select_model(runner, tmp_path):
+    create_example_project(tmp_path)
+    init_prod_and_backfill(runner, tmp_path)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "test",
+            "--select-model",
+            "sqlmesh_example.full_model",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Skipped 1 tests" in result.output
 
 
 def test_plan_skip_linter(runner, tmp_path):
@@ -343,7 +376,7 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
     assert_virtual_layer_updated(result)
     assert "Model batches executed" not in result.output
     # Dry-run still runs plan-scoped unit tests
-    assert "Successfully Ran 1 tests against duckdb" in result.output
+    assert "Successfully Ran 2 tests against duckdb" in result.output
 
 
 def test_plan_min_intervals(runner, tmp_path):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -274,27 +274,6 @@ def test_plan_runs_only_changed_model_tests(runner, tmp_path):
     assert "Successfully Ran 2 tests against duckdb" in result.output
 
 
-def test_plan_skip_backfill_all_tests(runner, tmp_path):
-    create_example_project(tmp_path)
-
-    result = runner.invoke(
-        cli,
-        [
-            "--log-file-dir",
-            tmp_path,
-            "--paths",
-            tmp_path,
-            "plan",
-            "--skip-backfill",
-            "--no-gaps",
-            "--all-tests",
-        ],
-        input="y\n",
-    )
-    assert result.exit_code == 0
-    assert "Successfully Ran 1 tests against duckdb" in result.output
-
-
 def test_plan_skip_linter(runner, tmp_path):
     create_example_project(tmp_path)
 
@@ -363,8 +342,8 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
     assert result.exit_code == 0
     assert_virtual_layer_updated(result)
     assert "Model batches executed" not in result.output
-    # --skip-backfill / --dry-run skips unit tests by default
-    assert "Successfully Ran" not in result.output
+    # Dry-run still runs plan-scoped unit tests
+    assert "Successfully Ran 1 tests against duckdb" in result.output
 
 
 def test_plan_min_intervals(runner, tmp_path):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -59,7 +59,7 @@ plan:
         )
 
 
-def add_unchanged_incremental_model_test(temp_dir) -> None:
+def add_incremental_model_test(temp_dir) -> None:
     with open(temp_dir / "tests" / "test_incremental_model.yaml", "w", encoding="utf-8") as f:
         f.write(
             """
@@ -221,7 +221,7 @@ def test_plan_skip_tests(runner, tmp_path):
 def test_plan_no_changes_runs_tests_by_default(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
-    add_unchanged_incremental_model_test(tmp_path)
+    add_incremental_model_test(tmp_path)
 
     result = runner.invoke(
         cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts"], input="\n"
@@ -255,7 +255,7 @@ def test_plan_test_changed_only_with_no_changes(runner, tmp_path):
 def test_plan_test_changed_only_runs_only_changed_model_tests(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
-    add_unchanged_incremental_model_test(tmp_path)
+    add_incremental_model_test(tmp_path)
 
     full_model_path = tmp_path / "models" / "full_model.sql"
     full_model_path.write_text(
@@ -283,7 +283,7 @@ def test_plan_test_changed_only_runs_only_changed_model_tests(runner, tmp_path):
 def test_plan_select_model_test_changed_only_scopes_tests(runner, tmp_path):
     create_example_project(tmp_path)
     init_prod_and_backfill(runner, tmp_path)
-    add_unchanged_incremental_model_test(tmp_path)
+    add_incremental_model_test(tmp_path)
 
     full_model_path = tmp_path / "models" / "full_model.sql"
     full_model_path.write_text(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -385,8 +385,6 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
     assert result.exit_code == 0
     assert_virtual_layer_updated(result)
     assert "Model batches executed" not in result.output
-    # Dry-run still runs plan-scoped unit tests
-    assert "Successfully Ran 1 tests against duckdb" in result.output
 
 
 def test_plan_min_intervals(runner, tmp_path):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -286,27 +286,6 @@ def test_plan_select_model_test_changed_only_scopes_tests(runner, tmp_path):
     assert "Skipped 1 tests" in result.output
 
 
-def test_test_select_model(runner, tmp_path):
-    create_example_project(tmp_path)
-    init_prod_and_backfill(runner, tmp_path)
-
-    result = runner.invoke(
-        cli,
-        [
-            "--log-file-dir",
-            tmp_path,
-            "--paths",
-            tmp_path,
-            "test",
-            "--select-model",
-            "sqlmesh_example.full_model",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "Successfully Ran 1 tests against duckdb" in result.output
-    assert "Skipped 1 tests" in result.output
-
-
 def test_plan_skip_linter(runner, tmp_path):
     create_example_project(tmp_path)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -193,6 +193,53 @@ def test_plan_skip_tests(runner, tmp_path):
     assert_backfill_success(result)
 
 
+def test_plan_no_changes_skips_tests(runner, tmp_path):
+    create_example_project(tmp_path)
+    init_prod_and_backfill(runner, tmp_path)
+
+    # No model changes: unit tests should not run
+    result = runner.invoke(
+        cli, ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--no-prompts"], input="\n"
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran" not in result.output
+    assert "No changes to plan" in result.output or "No changes" in result.output
+
+
+def test_plan_all_tests_with_no_changes(runner, tmp_path):
+    create_example_project(tmp_path)
+    init_prod_and_backfill(runner, tmp_path)
+
+    result = runner.invoke(
+        cli,
+        ["--log-file-dir", tmp_path, "--paths", tmp_path, "plan", "--all-tests", "--no-prompts"],
+        input="\n",
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 1 tests against duckdb" in result.output
+
+
+def test_plan_skip_backfill_all_tests(runner, tmp_path):
+    create_example_project(tmp_path)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--log-file-dir",
+            tmp_path,
+            "--paths",
+            tmp_path,
+            "plan",
+            "--skip-backfill",
+            "--no-gaps",
+            "--all-tests",
+        ],
+        input="y\n",
+    )
+    assert result.exit_code == 0
+    assert "Successfully Ran 1 tests against duckdb" in result.output
+
+
 def test_plan_skip_linter(runner, tmp_path):
     create_example_project(tmp_path)
 
@@ -261,6 +308,8 @@ def test_plan_skip_backfill(runner, tmp_path, flag):
     assert result.exit_code == 0
     assert_virtual_layer_updated(result)
     assert "Model batches executed" not in result.output
+    # --skip-backfill / --dry-run skips unit tests by default
+    assert "Successfully Ran" not in result.output
 
 
 def test_plan_min_intervals(runner, tmp_path):

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3592,9 +3592,7 @@ def test_prompt_if_uncategorized_snapshot(mocker: MockerFixture, tmp_path: Path)
     spy_plan = mocker.spy(mock_console, "plan")
     context.console = mock_console
 
-    # Skip tests: we break incremental_model above, which fails its example unit test
-    # and would raise PlanError before we reach the uncategorized-snapshot prompt logic.
-    context.plan(skip_tests=True)
+    context.plan()
 
     calls = spy_plan.mock_calls
     assert len(calls) == 1

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3592,7 +3592,9 @@ def test_prompt_if_uncategorized_snapshot(mocker: MockerFixture, tmp_path: Path)
     spy_plan = mocker.spy(mock_console, "plan")
     context.console = mock_console
 
-    context.plan()
+    # Skip tests: we break incremental_model above, which fails its example unit test
+    # and would raise PlanError before we reach the uncategorized-snapshot prompt logic.
+    context.plan(skip_tests=True)
 
     calls = spy_plan.mock_calls
     assert len(calls) == 1

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3603,11 +3603,19 @@ def test_prompt_if_uncategorized_snapshot(mocker: MockerFixture, tmp_path: Path)
     assert context.config.plan.no_prompts == True
 
 
+def test_plan_skip_tests_and_test_changed_only(sushi_context: Context) -> None:
+    with pytest.raises(
+        PlanError,
+        match="Cannot combine --skip-tests with --test-changed-only.",
+    ):
+        sushi_context.plan("dev", skip_tests=True, test_changed_only=True, no_prompts=True)
+
+
 def test_plan_explain_skips_tests(sushi_context: Context, mocker: MockerFixture) -> None:
     sushi_context.console = TerminalConsole()
     spy = mocker.spy(sushi_context, "_run_plan_tests")
     sushi_context.plan(environment="dev", explain=True, no_prompts=True, include_unmodified=True)
-    spy.assert_called_once_with(skip_tests=True, all_tests=False, model_names=ANY)
+    spy.assert_called_once_with(skip_tests=True, test_changed_only=False, model_names=ANY)
 
 
 def test_dev_environment_virtual_update_with_environment_statements(tmp_path: Path) -> None:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -4,7 +4,7 @@ import typing as t
 import re
 from datetime import date, timedelta, datetime
 from tempfile import TemporaryDirectory
-from unittest.mock import PropertyMock, call, patch
+from unittest.mock import ANY, PropertyMock, call, patch
 
 import time_machine
 import pytest
@@ -3607,7 +3607,7 @@ def test_plan_explain_skips_tests(sushi_context: Context, mocker: MockerFixture)
     sushi_context.console = TerminalConsole()
     spy = mocker.spy(sushi_context, "_run_plan_tests")
     sushi_context.plan(environment="dev", explain=True, no_prompts=True, include_unmodified=True)
-    spy.assert_called_once_with(skip_tests=True)
+    spy.assert_called_once_with(skip_tests=True, all_tests=False, model_names=ANY)
 
 
 def test_dev_environment_virtual_update_with_environment_statements(tmp_path: Path) -> None:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -3557,6 +3557,27 @@ def test_filter_tests_by_model_names():
 
 def test_plan_scoped_unit_tests(tmp_path: Path, mocker: MockerFixture):
     init_example_project(tmp_path, engine_type="duckdb")
+    # Second unit test so scoped plans (1 test) differ from --all-tests (2 tests)
+    (tmp_path / "tests" / "test_incremental_model.yaml").write_text(
+        """test_example_incremental_model:
+  model: sqlmesh_example.incremental_model
+  vars:
+    start: 2020-01-01
+    end: 2020-01-02
+  inputs:
+    sqlmesh_example.seed_model:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+  outputs:
+    query:
+      rows:
+      - id: 1
+        item_id: 1
+        event_date: 2020-01-01
+"""
+    )
     config = Config(
         gateways={"duckdb": GatewayConfig(connection=DuckDBConnectionConfig())},
         model_defaults=ModelDefaultsConfig(dialect="duckdb"),
@@ -3564,16 +3585,15 @@ def test_plan_scoped_unit_tests(tmp_path: Path, mocker: MockerFixture):
     context = Context(paths=tmp_path, config=config)
     context.plan("prod", auto_apply=True, no_prompts=True)
 
-    calls: t.List[t.Dict[str, t.Any]] = []
+    calls: t.List[t.Tuple[t.Dict[str, t.Any], int]] = []
+    original_test = context.test
 
-    def fake_test(**kwargs: t.Any) -> ModelTextTestResult:
-        calls.append(kwargs)
-        result = mocker.MagicMock(spec=ModelTextTestResult)
-        result.wasSuccessful.return_value = True
-        result.testsRun = 0
+    def tracking_test(**kwargs: t.Any) -> ModelTextTestResult:
+        result = original_test(**kwargs)
+        calls.append((kwargs, result.testsRun))
         return result
 
-    mocker.patch.object(context, "test", side_effect=fake_test)
+    mocker.patch.object(context, "test", side_effect=tracking_test)
 
     # No-op plan should not run tests
     context.plan("prod", auto_apply=True, no_prompts=True)
@@ -3582,26 +3602,27 @@ def test_plan_scoped_unit_tests(tmp_path: Path, mocker: MockerFixture):
     # --all-tests on no-op should run the full suite
     context.plan("prod", auto_apply=True, no_prompts=True, all_tests=True)
     assert len(calls) == 1
-    assert calls[0].get("model_names") is None
+    assert calls[0][0].get("model_names") is None
+    assert calls[0][1] == 2
 
     calls.clear()
 
-    # Changing one model should only pass that model's name into test()
+    # Changing full_model should only run that model's unit test
     model_path = tmp_path / "models" / "full_model.sql"
     model_path.write_text(model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)"))
     context.load()
     context.plan("prod", auto_apply=True, no_prompts=True)
     assert len(calls) == 1
-    model_names = calls[0].get("model_names")
-    assert model_names is not None
-    assert any("full_model" in name for name in model_names)
-    assert not any("seed_model" in name for name in model_names)
+    model_names = calls[0][0].get("model_names")
+    assert model_names == {'"memory"."sqlmesh_example"."full_model"'}
+    assert calls[0][1] == 1
 
     calls.clear()
 
-    # --all-tests with real changes still runs the full suite (no model filter)
+    # --all-tests with real changes still runs the full suite
     model_path.write_text(model_path.read_text().replace("COUNT(id)", "COUNT(DISTINCT id)"))
     context.load()
     context.plan("prod", auto_apply=True, no_prompts=True, all_tests=True)
     assert len(calls) == 1
-    assert calls[0].get("model_names") is None
+    assert calls[0][0].get("model_names") is None
+    assert calls[0][1] == 2

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -3527,3 +3527,81 @@ test_foo:
 
     assert "Ran 1 tests" in output
     assert "Failed tests (1)" in output
+
+
+def test_filter_tests_by_model_names():
+    from sqlmesh.core.test.discovery import ModelTestMetadata, filter_tests_by_model_names
+
+    tests = [
+        ModelTestMetadata(path=Path("a.yaml"), test_name="t1", body={"model": "sushi.a"}),
+        ModelTestMetadata(path=Path("b.yaml"), test_name="t2", body={"model": "sushi.b"}),
+        ModelTestMetadata(path=Path("c.yaml"), test_name="t3", body={"model": ""}),
+    ]
+
+    filtered = filter_tests_by_model_names(
+        tests,
+        {'"memory"."sushi"."a"'},
+        default_catalog="memory",
+        dialect="duckdb",
+    )
+    assert [t.test_name for t in filtered] == ["t1"]
+
+    filtered_short = filter_tests_by_model_names(
+        tests,
+        {"sushi.a"},
+        default_catalog="memory",
+        dialect="duckdb",
+    )
+    assert [t.test_name for t in filtered_short] == ["t1"]
+
+
+def test_plan_scoped_unit_tests(tmp_path: Path, mocker: MockerFixture):
+    init_example_project(tmp_path, engine_type="duckdb")
+    config = Config(
+        gateways={"duckdb": GatewayConfig(connection=DuckDBConnectionConfig())},
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+    )
+    context = Context(paths=tmp_path, config=config)
+    context.plan("prod", auto_apply=True, no_prompts=True)
+
+    calls: t.List[t.Dict[str, t.Any]] = []
+
+    def fake_test(**kwargs: t.Any) -> ModelTextTestResult:
+        calls.append(kwargs)
+        result = mocker.MagicMock(spec=ModelTextTestResult)
+        result.wasSuccessful.return_value = True
+        result.testsRun = 0
+        return result
+
+    mocker.patch.object(context, "test", side_effect=fake_test)
+
+    # No-op plan should not run tests
+    context.plan("prod", auto_apply=True, no_prompts=True)
+    assert calls == []
+
+    # --all-tests on no-op should run the full suite
+    context.plan("prod", auto_apply=True, no_prompts=True, all_tests=True)
+    assert len(calls) == 1
+    assert calls[0].get("model_names") is None
+
+    calls.clear()
+
+    # Changing one model should only pass that model's name into test()
+    model_path = tmp_path / "models" / "full_model.sql"
+    model_path.write_text(model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)"))
+    context.load()
+    context.plan("prod", auto_apply=True, no_prompts=True)
+    assert len(calls) == 1
+    model_names = calls[0].get("model_names")
+    assert model_names is not None
+    assert any("full_model" in name for name in model_names)
+    assert not any("seed_model" in name for name in model_names)
+
+    calls.clear()
+
+    # --all-tests with real changes still runs the full suite (no model filter)
+    model_path.write_text(model_path.read_text().replace("COUNT(id)", "COUNT(DISTINCT id)"))
+    context.load()
+    context.plan("prod", auto_apply=True, no_prompts=True, all_tests=True)
+    assert len(calls) == 1
+    assert calls[0].get("model_names") is None

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -3553,12 +3553,3 @@ def test_filter_tests_by_model_names():
         dialect="duckdb",
     )
     assert [t.test_name for t in filtered_short] == ["t1"]
-
-
-def test_test_select_model(tmp_path: Path) -> None:
-    init_example_project(tmp_path, engine_type="duckdb")
-    context = Context(paths=tmp_path)
-
-    results = context.test(model_names=["sqlmesh_example.full_model"])
-    assert len(results.successes) == 1
-    assert results.tests_skipped == 1

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2622,13 +2622,13 @@ test_example_full_model:
         f"""Model '"invalid_model"' was not found at {wrong_test_file}"""
         in mock_logger.call_args[0][0]
     )
-    assert "Successfully Ran 2 tests" in output.stdout
+    assert "Successfully Ran 1 test" in output.stdout
 
 
 def test_number_of_tests_found(tmp_path: Path) -> None:
     init_example_project(tmp_path, engine_type="duckdb")
 
-    # Example project contains 2 tests and we add a new file with 2 tests
+    # Example project contains 1 test and we add a new file with 2 tests
     test_file = tmp_path / "tests" / "test_new.yaml"
     test_file.write_text(
         """
@@ -2674,9 +2674,9 @@ test_example_full_model2:
 
     context = Context(paths=tmp_path)
 
-    # Case 1: All 4 tests should run without any tests specified
+    # Case 1: All 3 tests should run without any tests specified
     results = context.test()
-    assert len(results.successes) == 4
+    assert len(results.successes) == 3
 
     # Case 2: The "new_test.yaml" should amount to 2 subtests
     results = context.test(tests=[f"{test_file}"])

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -3553,3 +3553,12 @@ def test_filter_tests_by_model_names():
         dialect="duckdb",
     )
     assert [t.test_name for t in filtered_short] == ["t1"]
+
+
+def test_test_select_model(tmp_path: Path) -> None:
+    init_example_project(tmp_path, engine_type="duckdb")
+    context = Context(paths=tmp_path)
+
+    results = context.test(model_names=["sqlmesh_example.full_model"])
+    assert len(results.successes) == 1
+    assert results.tests_skipped == 1

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2622,13 +2622,13 @@ test_example_full_model:
         f"""Model '"invalid_model"' was not found at {wrong_test_file}"""
         in mock_logger.call_args[0][0]
     )
-    assert "Successfully Ran 1 test" in output.stdout
+    assert "Successfully Ran 2 tests" in output.stdout
 
 
 def test_number_of_tests_found(tmp_path: Path) -> None:
     init_example_project(tmp_path, engine_type="duckdb")
 
-    # Example project contains 1 test and we add a new file with 2 tests
+    # Example project contains 2 tests and we add a new file with 2 tests
     test_file = tmp_path / "tests" / "test_new.yaml"
     test_file.write_text(
         """
@@ -2674,9 +2674,9 @@ test_example_full_model2:
 
     context = Context(paths=tmp_path)
 
-    # Case 1: All 3 tests should run without any tests specified
+    # Case 1: All 4 tests should run without any tests specified
     results = context.test()
-    assert len(results.successes) == 3
+    assert len(results.successes) == 4
 
     # Case 2: The "new_test.yaml" should amount to 2 subtests
     results = context.test(tests=[f"{test_file}"])
@@ -3553,76 +3553,3 @@ def test_filter_tests_by_model_names():
         dialect="duckdb",
     )
     assert [t.test_name for t in filtered_short] == ["t1"]
-
-
-def test_plan_scoped_unit_tests(tmp_path: Path, mocker: MockerFixture):
-    init_example_project(tmp_path, engine_type="duckdb")
-    # Second unit test so scoped plans (1 test) differ from --all-tests (2 tests)
-    (tmp_path / "tests" / "test_incremental_model.yaml").write_text(
-        """test_example_incremental_model:
-  model: sqlmesh_example.incremental_model
-  vars:
-    start: 2020-01-01
-    end: 2020-01-02
-  inputs:
-    sqlmesh_example.seed_model:
-      rows:
-      - id: 1
-        item_id: 1
-        event_date: 2020-01-01
-  outputs:
-    query:
-      rows:
-      - id: 1
-        item_id: 1
-        event_date: 2020-01-01
-"""
-    )
-    config = Config(
-        gateways={"duckdb": GatewayConfig(connection=DuckDBConnectionConfig())},
-        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
-    )
-    context = Context(paths=tmp_path, config=config)
-    context.plan("prod", auto_apply=True, no_prompts=True)
-
-    calls: t.List[t.Tuple[t.Dict[str, t.Any], int]] = []
-    original_test = context.test
-
-    def tracking_test(**kwargs: t.Any) -> ModelTextTestResult:
-        result = original_test(**kwargs)
-        calls.append((kwargs, result.testsRun))
-        return result
-
-    mocker.patch.object(context, "test", side_effect=tracking_test)
-
-    # No-op plan should not run tests
-    context.plan("prod", auto_apply=True, no_prompts=True)
-    assert calls == []
-
-    # --all-tests on no-op should run the full suite
-    context.plan("prod", auto_apply=True, no_prompts=True, all_tests=True)
-    assert len(calls) == 1
-    assert calls[0][0].get("model_names") is None
-    assert calls[0][1] == 2
-
-    calls.clear()
-
-    # Changing full_model should only run that model's unit test
-    model_path = tmp_path / "models" / "full_model.sql"
-    model_path.write_text(model_path.read_text().replace("COUNT(DISTINCT id)", "COUNT(id)"))
-    context.load()
-    context.plan("prod", auto_apply=True, no_prompts=True)
-    assert len(calls) == 1
-    model_names = calls[0][0].get("model_names")
-    assert model_names == {'"memory"."sqlmesh_example"."full_model"'}
-    assert calls[0][1] == 1
-
-    calls.clear()
-
-    # --all-tests with real changes still runs the full suite
-    model_path.write_text(model_path.read_text().replace("COUNT(id)", "COUNT(DISTINCT id)"))
-    context.load()
-    context.plan("prod", auto_apply=True, no_prompts=True, all_tests=True)
-    assert len(calls) == 1
-    assert calls[0][0].get("model_names") is None
-    assert calls[0][1] == 2

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -3,7 +3,7 @@ import typing as t
 import os
 import pathlib
 from unittest import mock
-from unittest.mock import PropertyMock, call
+from unittest.mock import ANY, PropertyMock, call
 
 import pytest
 import time_machine
@@ -256,7 +256,9 @@ def test_pr_plan(github_client, make_controller):
     assert controller.pr_plan.skip_backfill
     assert not controller.pr_plan.no_gaps
     assert not controller._context.apply.called
-    assert controller._context._run_plan_tests.call_args == call(skip_tests=True)
+    assert controller._context._run_plan_tests.call_args == call(
+        skip_tests=True, all_tests=False, model_names=ANY
+    )
     assert (
         controller._pr_plan_builder._categorizer_config
         == controller._context.auto_categorize_changes
@@ -278,7 +280,9 @@ def test_pr_plan_auto_categorization(github_client, make_controller):
     assert controller.pr_plan.skip_backfill
     assert not controller.pr_plan.no_gaps
     assert not controller._context.apply.called
-    assert controller._context._run_plan_tests.call_args == call(skip_tests=True)
+    assert controller._context._run_plan_tests.call_args == call(
+        skip_tests=True, all_tests=False, model_names=ANY
+    )
     assert controller._pr_plan_builder._categorizer_config == custom_categorizer_config
     assert controller.pr_plan.start == default_start_absolute
     assert not controller.pr_plan.start_override_per_model
@@ -365,7 +369,9 @@ def test_prod_plan(github_client, make_controller):
     assert not controller.prod_plan.skip_backfill
     assert controller.prod_plan.no_gaps
     assert not controller._context.apply.called
-    assert controller._context._run_plan_tests.call_args == call(skip_tests=True)
+    assert controller._context._run_plan_tests.call_args == call(
+        skip_tests=True, all_tests=False, model_names=ANY
+    )
     assert (
         controller._prod_plan_builder._categorizer_config
         == controller._context.auto_categorize_changes
@@ -387,7 +393,9 @@ def test_prod_plan_auto_categorization(github_client, make_controller):
     assert not controller.prod_plan.skip_backfill
     assert controller.prod_plan.no_gaps
     assert not controller._context.apply.called
-    assert controller._context._run_plan_tests.call_args == call(skip_tests=True)
+    assert controller._context._run_plan_tests.call_args == call(
+        skip_tests=True, all_tests=False, model_names=ANY
+    )
     assert controller._prod_plan_builder._categorizer_config == custom_categorizer_config
     # default PR start should be ignored for prod plans
     assert controller.prod_plan.start != default_pr_start
@@ -404,7 +412,9 @@ def test_prod_plan_with_gaps(github_client, make_controller):
     assert controller._prod_plan_with_gaps_builder._auto_categorization_enabled
     assert not controller.prod_plan_with_gaps.no_gaps
     assert not controller._context.apply.called
-    assert controller._context._run_plan_tests.call_args == call(skip_tests=True)
+    assert controller._context._run_plan_tests.call_args == call(
+        skip_tests=True, all_tests=False, model_names=ANY
+    )
 
 
 def test_run_tests(github_client, make_controller):

--- a/tests/integrations/github/cicd/test_github_controller.py
+++ b/tests/integrations/github/cicd/test_github_controller.py
@@ -257,7 +257,7 @@ def test_pr_plan(github_client, make_controller):
     assert not controller.pr_plan.no_gaps
     assert not controller._context.apply.called
     assert controller._context._run_plan_tests.call_args == call(
-        skip_tests=True, all_tests=False, model_names=ANY
+        skip_tests=True, test_changed_only=False, model_names=ANY
     )
     assert (
         controller._pr_plan_builder._categorizer_config
@@ -281,7 +281,7 @@ def test_pr_plan_auto_categorization(github_client, make_controller):
     assert not controller.pr_plan.no_gaps
     assert not controller._context.apply.called
     assert controller._context._run_plan_tests.call_args == call(
-        skip_tests=True, all_tests=False, model_names=ANY
+        skip_tests=True, test_changed_only=False, model_names=ANY
     )
     assert controller._pr_plan_builder._categorizer_config == custom_categorizer_config
     assert controller.pr_plan.start == default_start_absolute
@@ -370,7 +370,7 @@ def test_prod_plan(github_client, make_controller):
     assert controller.prod_plan.no_gaps
     assert not controller._context.apply.called
     assert controller._context._run_plan_tests.call_args == call(
-        skip_tests=True, all_tests=False, model_names=ANY
+        skip_tests=True, test_changed_only=False, model_names=ANY
     )
     assert (
         controller._prod_plan_builder._categorizer_config
@@ -394,7 +394,7 @@ def test_prod_plan_auto_categorization(github_client, make_controller):
     assert controller.prod_plan.no_gaps
     assert not controller._context.apply.called
     assert controller._context._run_plan_tests.call_args == call(
-        skip_tests=True, all_tests=False, model_names=ANY
+        skip_tests=True, test_changed_only=False, model_names=ANY
     )
     assert controller._prod_plan_builder._categorizer_config == custom_categorizer_config
     # default PR start should be ignored for prod plans
@@ -413,7 +413,7 @@ def test_prod_plan_with_gaps(github_client, make_controller):
     assert not controller.prod_plan_with_gaps.no_gaps
     assert not controller._context.apply.called
     assert controller._context._run_plan_tests.call_args == call(
-        skip_tests=True, all_tests=False, model_names=ANY
+        skip_tests=True, test_changed_only=False, model_names=ANY
     )
 
 


### PR DESCRIPTION
## Description

- Add in `--test-changed-only` flag to only run tests for changed models in the plan.
- Default behavior remains running all tests for all models
- Add `--select-model` flag to the `test` command for improved functionality

Addresses #5965

## Test Plan
- [X] Plan runs all unit tests by default (including no-change plans)
- [X] Plan with model changes runs the full suite unless --test-changed-only is set
- [X] --test-changed-only runs only changed/restated models’ unit tests
- [X] Plan with no changes and --test-changed-only skips unit tests
- [X] --skip-tests still skips; incompatible with --test-changed-only
- [X] Docs cover run-all default and --test-changed-only

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
