### PR TITLE
chore: Resolve starlette deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
     "google-auth",
     "google-cloud-bigquery",
     "google-cloud-bigquery-storage",
-    "httpx",
+    "httpx2",
     "mypy~=1.13.0",
     "numpy",
     "pandas-stubs",

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -7,7 +7,7 @@ import pyarrow as pa  # type: ignore
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from httpx import ASGITransport, AsyncClient
+from httpx2 import ASGITransport, AsyncClient
 from pytest_mock.plugin import MockerFixture
 
 from sqlmesh.core.context import Context

--- a/web/server/exceptions.py
+++ b/web/server/exceptions.py
@@ -3,7 +3,7 @@ import traceback
 import typing as t
 
 from fastapi import HTTPException
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 
 from sqlmesh.utils.date import now_timestamp
 from web.server.models import ApiExceptionPayload
@@ -14,7 +14,7 @@ class ApiException(HTTPException):
         self,
         origin: str,
         message: str,
-        status_code: int = HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code: int = HTTP_422_UNPROCESSABLE_CONTENT,
         trigger: t.Optional[str] = None,
     ):
         super().__init__(status_code)

--- a/web/server/utils.py
+++ b/web/server/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path, PurePath
 import pyarrow as pa  # type: ignore
 from fastapi import Depends, HTTPException
 from starlette.responses import StreamingResponse
-from starlette.status import HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY
+from starlette.status import HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_CONTENT
 
 from sqlmesh.core import constants as c
 from web.server.console import api_console
@@ -45,7 +45,7 @@ async def run_in_executor(func: t.Callable[..., R], *args: t.Any) -> R:
                     message="An unexpected error occurred",
                     origin="API -> utils -> run_in_executor",
                     trigger="An unexpected error occurred",
-                    status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=HTTP_422_UNPROCESSABLE_CONTENT,
                 )
             )
             raise e


### PR DESCRIPTION
## Description

I have:
- Changed the webserver exception type of `HTTP_422_UNPROCESSABLE_ENTITY` to `HTTP_422_UNPROCESSABLE_CONTENT`.
  - `HTTP_422_UNPROCESSABLE_ENTITY` is deprecated due to changes to [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-422-unprocessable-content).
  - `HTTP_422_UNPROCESSABLE_CONTENT` has been available since `starlette==0.48.0`, and the minimum version in `pyproject.toml` is `>=1.0.1`.
- Changed the httpx dev requirement to httpx2, as the use of `httpx` with `starlette.testclient` is deprecated.

## Test Plan

- For the change to 422 HTTP responses, these are covered by tests in `tests/web/test_main.py` (including but not limited to; `test_rename_file_to_existing_directory`, `test_create_directory_already_exists`, `test_rename_directory_already_exists_not_empty`)
- For the change of httpx to httpx2, this package is only used in the test `tests/web/test_main.py::test_cancel`, which still passes.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
