### PR TITLE
fix: stabilize disable restatement test at UTC boundary

### DIFF
--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -2026,6 +2026,7 @@ def test_added_forward_only_model(make_snapshot, mocker: MockerFixture):
     assert snapshot_b.change_category == SnapshotChangeCategory.BREAKING
 
 
+@time_machine.travel("2026-08-22 15:00:00 UTC")
 def test_disable_restatement(make_snapshot, mocker: MockerFixture):
     snapshot = make_snapshot(
         SqlModel(


### PR DESCRIPTION
## Description

Fixes #5976.

Pin `test_disable_restatement` to a fixed mid-day UTC timestamp so the plan build and its relative `tomorrow` assertion cannot cross a UTC date boundary during a long test run.

## Test Plan

- `uv run --no-sync pytest tests/core/test_plan.py::test_disable_restatement -q -n 0` (1 passed)
- `uv run --no-sync ruff check tests/core/test_plan.py`
- `uv run --no-sync ruff format --check tests/core/test_plan.py`

## Checklist

- [ ] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
