### PR TITLE
feat: add audit_pass notification event

### DIFF
--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -130,7 +130,7 @@ This example stops all notifications other than those for `User1`:
 
 SQLMesh notifications are triggered by events. The events that should trigger a notification are specified in the notification target's `notify_on` field.
 
-Notifications are supported for [`plan` application](../concepts/plans.md) start/end/failure, [`run`](../reference/cli.md#run) start/end/failure, and [`audit`](../concepts/audits.md) failures.
+Notifications are supported for [`plan` application](../concepts/plans.md) start/end/failure, [`run`](../reference/cli.md#run) start/end/failure, and [`audit`](../concepts/audits.md) passes and failures.
 
 For `plan` and `run` start/end, the target environment name is included in the notification message. For failures, the Python exception or error text is included in the notification message.
 
@@ -145,6 +145,7 @@ This table lists each event, its associated `notify_on` value, and its notificat
 | SQLMesh run end               | run_end                | "SQLMesh run finished for environment `{environment}`."  |
 | SQLMesh run failure           | run_failure            | "Failed to run SQLMesh.\n{exception}"                    |
 | Audit failure                 | audit_failure          | "{audit_error}"                                          |
+| Audit pass                    | audit_pass             | "Audit `{audit_name}` passed for model `{model_name}`."  |
 
 Any combination of these events can be specified in a notification target's `notify_on` field.
 
@@ -269,6 +270,7 @@ Each of those notification target classes is a subclass of `BaseNotificationTarg
 | notify_run_end       | Environment name: `env`          |
 | notify_run_failure   | Exception stack trace: `exc`     |
 | notify_audit_failure | Audit error trace: `audit_error` |
+| notify_audit_pass    | Audit name: `audit_name`, model name: `model_name` |
 
 This example creates a new notification target class `CustomSMTPNotificationTarget`.
 

--- a/sqlmesh/core/notification_target.py
+++ b/sqlmesh/core/notification_target.py
@@ -64,6 +64,7 @@ class NotificationEvent(str, Enum):
     APPLY_FAILURE = "apply_failure"
     RUN_FAILURE = "run_failure"
     AUDIT_FAILURE = "audit_failure"
+    AUDIT_PASS = "audit_pass"
     MIGRATION_FAILURE = "migration_failure"
 
 
@@ -171,6 +172,21 @@ class BaseNotificationTarget(PydanticModel, frozen=True):
             audit_error: The AuditError object.
         """
         self.send(NotificationStatus.FAILURE, "Audit failure.", audit_error=audit_error)
+
+    def notify_audit_pass(
+        self, audit_name: str, model_name: t.Optional[str] = None, *args: t.Any, **kwargs: t.Any
+    ) -> None:
+        """Notify when an audit passes.
+
+        Args:
+            audit_name: The name of the audit that passed.
+            model_name: The name of the model the audit ran against, if any.
+        """
+        if model_name:
+            msg = f"Audit `{audit_name}` passed for model `{model_name}`."
+        else:
+            msg = f"Audit `{audit_name}` passed."
+        self.send(NotificationStatus.SUCCESS, msg)
 
     def notify_migration_failure(self, exc: str, *args: t.Any, **kwargs: t.Any) -> None:
         """Notify in the case of a migration failure.

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -930,6 +930,20 @@ class Scheduler:
             else:
                 audit_errors_to_warn.append(error)
 
+        model = snapshot.model_or_none
+        model_name = model.name if model else None
+        for audit_result in audit_results:
+            if audit_result.skipped or audit_result.count:
+                continue
+            audit_name = audit_result.audit.name
+            self.notification_target_manager.notify(
+                NotificationEvent.AUDIT_PASS, audit_name, model_name
+            )
+            if is_deployable and snapshot.node.owner:
+                self.notification_target_manager.notify_user(
+                    NotificationEvent.AUDIT_PASS, snapshot.node.owner, audit_name, model_name
+                )
+
         if audit_errors_to_raise:
             raise NodeAuditsErrors(audit_errors_to_raise)
 

--- a/tests/core/test_notification_target.py
+++ b/tests/core/test_notification_target.py
@@ -24,6 +24,7 @@ def notification_target_manager_with_spy(mocker) -> tuple[NotificationTargetMana
         notification_targets={
             NotificationEvent.APPLY_START: {console_notification_target},
             NotificationEvent.APPLY_END: {console_notification_target},
+            NotificationEvent.AUDIT_PASS: {console_notification_target},
         },
         user_notification_targets={
             "test_user": {test_user_console_notification_target},
@@ -55,6 +56,25 @@ def test_notify(notification_target_manager_with_spy):
         NotificationEvent.APPLY_FAILURE, "prod", "a-plan-id", ValueError()
     )
     spy.assert_not_called()
+
+
+def test_notify_audit_pass(notification_target_manager_with_spy):
+    notification_target_manager, spy = notification_target_manager_with_spy
+    notification_target_manager.notify(NotificationEvent.AUDIT_PASS, "not_null", "sushi.orders")
+    spy.assert_called_once_with(
+        mock.ANY,
+        NotificationStatus.SUCCESS,
+        "Audit `not_null` passed for model `sushi.orders`.",
+    )
+
+    # Without a model name the message omits the model reference
+    spy.reset_mock()
+    notification_target_manager.notify(NotificationEvent.AUDIT_PASS, "not_null")
+    spy.assert_called_once_with(
+        mock.ANY,
+        NotificationStatus.SUCCESS,
+        "Audit `not_null` passed.",
+    )
 
 
 def test_notify_user(notification_target_manager_with_spy):

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -588,6 +588,7 @@ def test_audit_failure_notifications(
             0,
         )
 
+    # A passing audit notifies AUDIT_PASS.
     evaluator_audit_mock.return_value = [
         AuditResult(
             audit=audit,
@@ -599,9 +600,12 @@ def test_audit_failure_notifications(
         )
     ]
     _evaluate()
-    assert notify_user_mock.call_count == 0
-    assert notify_mock.call_count == 0
+    assert notify_user_mock.call_count == 1
+    assert notify_mock.call_count == 1
+    notify_user_mock.reset_mock()
+    notify_mock.reset_mock()
 
+    # A skipped audit is neither a pass nor a failure, so nothing fires.
     evaluator_audit_mock.return_value = [
         AuditResult(
             audit=audit,


### PR DESCRIPTION
## Description

Closes #5865.

Audit failures can already be sent to notification targets, but passes cannot, so there is no way to track successful audits through the notification system without re-running them via the Python API or writing a custom target that only ever sees failures.

This adds an `AUDIT_PASS` notification event. When a non-blocking or blocking audit runs and returns no failing rows, `Scheduler._audit_snapshot` now fires `AUDIT_PASS` in the same place it already fires `AUDIT_FAILURE` for failing audits. Skipped audits are neither a pass nor a failure, so they don't notify. The event carries the audit name and the model name.

Nothing changes by default. A target only receives these notifications if `audit_pass` is in its `notify_on` set, so existing configs behave exactly as before.

```yaml
notification_targets:
  - type: slack_webhook
    url: ...
    notify_on:
      - audit_pass
      - audit_failure
```

## Test plan

- Added a `notify_audit_pass` unit test covering the message with and without a model name.
- Extended `test_audit_failure_notifications` so the passing-audit case asserts `AUDIT_PASS` fires (global and to the owner) and the skipped case still fires nothing.
- `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.
- `pytest tests/core/test_notification_target.py tests/core/test_scheduler.py` passes (27 tests).

## Checklist

- [x] I have run `make style` and fixed any issues.
- [x] I have added tests for my changes.
- [x] All existing tests pass.
- [x] My commits are signed off per the DCO.
