### PR TITLE
fix(bigquery): ci test now partitions correctly

### DIFF
--- a/tests/core/engine_adapter/integration/test_integration_bigquery.py
+++ b/tests/core/engine_adapter/integration/test_integration_bigquery.py
@@ -490,7 +490,7 @@ MODEL (
     cron '@daily',
     start '2023-01-07'
 );
-SELECT 1 AS col, '2023-01-07' AS event_ts
+SELECT 1 AS col, CAST('2023-01-07' AS DATE) AS event_ts
 """
             )
         )


### PR DESCRIPTION
## Description

Test plan failed due to not being able to partition the string column. Did explicit cast to date to fix.

## Test Plan

BigQuery CI succeeds

## Checklist

- [X] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
