### PR TITLE
fix(makefile): adding in retries on dev install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ else
 endif
 
 install-dev:
-	$(PIP) install -e ".[dev,web,slack,dlt,lsp]" ./examples/custom_materializations
+	@for i in 1 2 3; do \
+		$(PIP) install -e ".[dev,web,slack,dlt,lsp]" ./examples/custom_materializations && exit 0; \
+		echo "install-dev failed (attempt $$i/3), retrying..."; \
+		sleep 5; \
+	done; \
+	exit 1
 
 install-doc:
 	$(PIP) install -r ./docs/requirements.txt


### PR DESCRIPTION
## Description

Add in retries on `make install-dev` to make CI more resilient. Recent Spark build failed on `install-dev`

Closes #5974

## Test Plan

`install-dev` command success -- pip installs are idempotent with pinned versions.

## Checklist

- [X] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
