### PR TITLE
ci: add dbt 1.11 to test matrix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -457,7 +457,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ install-dev-dbt-%:
 		$(SED_INPLACE) -E 's/"(dbt-core)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \
 		$(SED_INPLACE) -E 's/"(dbt-(bigquery|duckdb|snowflake|athena-community|clickhouse|redshift|trino))[^"]*"/"\1"/g' pyproject.toml; \
 		$(SED_INPLACE) -E 's/"(dbt-databricks)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \
+	elif [ "$$version" = "1.11.0" ]; then \
+		echo "Applying special handling for dbt 1.11.0"; \
+		$(SED_INPLACE) -E 's/"(dbt-core)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \
+		$(SED_INPLACE) -E 's/"(dbt-(bigquery|duckdb|snowflake|athena-community|clickhouse|databricks|redshift|trino))[^"]*"/"\1"/g' pyproject.toml; \
 	else \
 		echo "Applying version $$version to all dbt packages"; \
 		$(SED_INPLACE) -E 's/"(dbt-[^"><=~!]+)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \


### PR DESCRIPTION
## Description

Closes #5992.

Adds dbt 1.11 to the CI compatibility matrix. For this version, the install target pins `dbt-core` to the 1.11 release line while allowing the adapter resolver to select compatible versions.

This special handling is needed because not every adapter has a 1.11 release, and forcing all adapters to `~=1.11.0` creates mutually incompatible dependency constraints. Existing handling for dbt 1.3 through 1.10 is unchanged.

## Test Plan

- Parsed `.github/workflows/pr.yaml` with PyYAML.
- Ran `git diff --check`.
- Installed the project with `dbt-core~=1.11.0` and all supported adapters; the resolver selected dbt-core 1.11.14 plus a compatible adapter set.
- Ran `sqlmesh info --skip-connection` in `examples/sushi_dbt` successfully (11 models parsed).
- Ran targeted dbt tests successfully in smaller groups. A monolithic Windows run hits an existing stack overflow in the lazy-import path, so the Linux CI job remains the authoritative full-suite check.

## Checklist

- [ ] I have run `make style` and fixed any issues (GNU Make is not available in this Windows environment; configuration files were validated directly)
- [x] I have added tests for my changes (not applicable; this change extends the existing CI matrix)
- [ ] All existing tests pass (`make fast-test`) (targeted checks pass; see Test Plan)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

AI assistance was used to help investigate adapter constraints and prepare the change; the resulting diff and verification were reviewed manually.
