### PR TITLE
fix(web): adjusting paths to fix windows

### DIFF
--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import threading
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pyarrow as pa  # type: ignore
 import pytest
@@ -73,6 +73,32 @@ def test_get_file(client: TestClient, project_tmp_path: Path) -> None:
         "extension": ".txt",
         "content": "bar",
     }
+
+
+def test_get_file_nested_path_matches_directory_listing(
+    client: TestClient, project_tmp_path: Path
+) -> None:
+    models_dir = project_tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "mymodel.sql").write_text("SELECT 1")
+
+    response = client.get("/api/files/models/mymodel.sql")
+    assert response.status_code == 200
+    assert response.json()["path"] == "models/mymodel.sql"
+
+
+def test_get_file_relative_path_uses_posix_separators(tmp_path: Path) -> None:
+    file_path = tmp_path / "models" / "mymodel.sql"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text("SELECT 1")
+
+    windows_relative = PureWindowsPath("models/mymodel.sql")
+    assert windows_relative.as_posix() == "models/mymodel.sql"
+    assert str(windows_relative) == "models\\mymodel.sql"
+
+    file = _get_file_with_content(file_path, windows_relative.as_posix())
+    assert file.path == "models/mymodel.sql"
+    assert file.path != str(windows_relative)
 
 
 def test_get_file_not_found(client: TestClient) -> None:

--- a/web/server/api/endpoints/files.py
+++ b/web/server/api/endpoints/files.py
@@ -37,7 +37,7 @@ def get_file(
     """Get a file, including its contents."""
     try:
         file_path = Path(path)
-        file = _get_file_with_content(settings.project_path / file_path, str(file_path))
+        file = _get_file_with_content(settings.project_path / file_path, file_path.as_posix())
     except FileNotFoundError:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND)
 
@@ -155,7 +155,7 @@ def _get_directory(path: str | Path, settings: Settings) -> models.Directory:
         return sorted(directories, key=lambda x: x.name), sorted(files, key=lambda x: x.name)
 
     directories, files = walk_path(path)
-    relative_path = str(Path(path).relative_to(settings.project_path))
+    relative_path = Path(path).relative_to(settings.project_path).as_posix()
 
     return models.Directory(
         name=os.path.basename(path),

--- a/web/server/watcher.py
+++ b/web/server/watcher.py
@@ -55,7 +55,7 @@ async def watch_project() -> None:
                     changes.append(
                         models.ArtifactChange(
                             change=Change.deleted,
-                            path=str(relative_path),
+                            path=relative_path.as_posix(),
                         )
                     )
                 elif change == Change.added:
@@ -69,9 +69,9 @@ async def watch_project() -> None:
                         models.ArtifactChange(
                             type=models.ArtifactType.file,
                             change=change,
-                            path=str(relative_path),
+                            path=relative_path.as_posix(),
                             file=_get_file_with_content(
-                                settings.project_path / relative_path, str(relative_path)
+                                settings.project_path / relative_path, relative_path.as_posix()
                             ),
                         )
                     )


### PR DESCRIPTION
## Description

Fixes path standardization so it works cross-platform and fixes window issue. Justification for fix is that `web` may be deprecated, but the VS extension is still prototype. Easy fix.

Closes #5945

## Test Plan

- [X] `test_get_file_nested_path_matches_directory_listing`
- [X] `test_get_file_relative_path_uses_posix_separators`

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
