### PR TITLE
chore(ci): add dbt 1.11 to the test matrix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -457,7 +457,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10', '1.11']
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ install-dev-dbt-%:
 	echo "Installing dbt version: $$version"; \
 	cp pyproject.toml pyproject.toml.backup; \
 	$(SED_INPLACE) 's/"pydantic>=2.0.0"/"pydantic"/g' pyproject.toml; \
-	if [ "$$version" = "1.10.0" ]; then \
-		echo "Applying special handling for dbt 1.10.0"; \
+	if [ "$$version" = "1.10.0" ] || [ "$$version" = "1.11.0" ]; then \
+		echo "Applying special handling for dbt $$version"; \
 		$(SED_INPLACE) -E 's/"(dbt-core)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \
 		$(SED_INPLACE) -E 's/"(dbt-(bigquery|duckdb|snowflake|athena-community|clickhouse|redshift|trino))[^"]*"/"\1"/g' pyproject.toml; \
 		$(SED_INPLACE) -E 's/"(dbt-databricks)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \


### PR DESCRIPTION
Closes #5992

Adds dbt 1.11 to the `test-dbt-versions` CI matrix.

The matrix line is the easy half. The issue flags that 1.11 "may need" the same special Makefile handling 1.10 got — it does, and without it the new matrix entry fails at install time.

## Why the Makefile change is required

`install-dev-dbt-%` pins **every** `dbt-*` package to `~=$version` on the default path. Two adapters have no 1.11 release at all:

| Adapter | Latest on PyPI |
|---|---|
| `dbt-trino` | 1.10.3 |
| `dbt-clickhouse` | 1.10.2 |

So the default path asks for `dbt-trino~=1.11.0` and the resolve is unsatisfiable:

```
$ uv pip compile  # dbt-core~=1.11.0, dbt-trino~=1.11.0, dbt-clickhouse~=1.11.0
  ... because dbt-trino>=1.11.0,<1.12.dev0 has no matching version, we can
  conclude that your requirements are unsatisfiable.
```

The fix is the branch that already exists for 1.10: pin `dbt-core` (and `dbt-databricks`), leave the adapters unpinned, and let the resolver find a consistent set. Extending that condition to 1.11 rather than adding a parallel branch keeps it to a two-line change, and the `$$version` interpolation was already there — only the hardcoded `1.10.0` in the echo needed generalising.

Resolved set with the fix:

```
dbt-core==1.11.8        dbt-bigquery==1.11.3     dbt-trino==1.10.3
dbt-databricks==1.11.8  dbt-snowflake==1.11.6    dbt-clickhouse==1.10.2
dbt-duckdb==1.11.0      dbt-redshift==1.10.2     dbt-athena-community==1.10.2
```

## Gotchas from the issue, checked

- **numpy** — 1.11 pulls numpy 2.2.6. The `numpy<2` awk condition was **not** extended, because the suite passes on numpy 2; adding the constraint would have been a change with nothing behind it.
- **pydantic** — installs 2.12.5 on the full dev path, no `1.6`-style special casing needed.
- **`dbt-duckdb` / `dbt-snowflake!=1.10.1` pins** — both resolve cleanly under the unpinned branch.
- **No CI script changes.** The version-gated shell in the job holds for 1.11: the semantic_models/metrics strip is an explicit `1.3|1.4|1.5` list, the pytest-path fork is `== "1.6"`, and the version-params check uses `sort -V`, which orders `1.11` above `1.5.0` correctly (a naive string compare would not):

  ```
  dbt 1.10   sort -V first=1.5.0   >= 1.5.0 -> keeps version params
  dbt 1.11   sort -V first=1.5.0   >= 1.5.0 -> keeps version params
  ```

- **Version-gated tests** — the only upper-bound gates in `tests/dbt/` are `DBT_VERSION < (1, 9, 5)` in `test_manifest.py`, which 1.11 takes the `else` side of. Already correct, no change.

## Verification

Locally, on Python 3.10 to match the job:

```
UV=1 make install-dev-dbt-1.11     # succeeds; DBT_VERSION == (1, 11, 8)
make dbt-fast-test                 # 88 passed, 84.87s
cd examples/sushi_dbt && sqlmesh info --skip-connection   # Models: 11, Macros: 0 (exit 0)
```

## Acceptance criteria

- [x] `'1.11'` in the `test-dbt-versions` matrix
- [x] `UV=1 make install-dev-dbt-1.11` succeeds locally
- [x] `make dbt-fast-test` passes
- [x] `sqlmesh info --skip-connection` works in `examples/sushi_dbt`
- [x] CI green on this PR
