### PR TITLE
feature(ci): filter dbt tests to same as python tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -453,6 +453,10 @@ jobs:
           path: vscode/extension/playwright-report/
           retention-days: 30
   test-dbt-versions:
+    needs: changes
+    if:
+      needs.changes.outputs.python == 'true' || needs.changes.outputs.ci ==
+      'true' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Copying Python version CI tests filters to DBT versions. Limits DBT CI jobs from firing for Docs or Extension work. My Doc changes keep triggering DBT versions jobs.

Here's an Example PR that's triggering DBT tests when it doesn't need to: https://github.com/SQLMesh/sqlmesh/pull/6050

## Test Plan

Running CI. 

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
