### PR TITLE
fix(clickhouse): register table comments via command instead of inline CTAS

### DIFF
--- a/sqlmesh/core/engine_adapter/clickhouse.py
+++ b/sqlmesh/core/engine_adapter/clickhouse.py
@@ -13,6 +13,7 @@ from sqlmesh.core.engine_adapter.shared import (
     DataObjectType,
     EngineRunMode,
     SourceQuery,
+    CommentCreationTable,
     CommentCreationView,
     InsertOverwriteStrategy,
 )
@@ -36,6 +37,7 @@ class ClickhouseEngineAdapter(EngineAdapterWithIndexSupport, LogicalMergeMixin):
     SUPPORTS_TRANSACTIONS = False
     SUPPORTS_VIEW_SCHEMA = False
     SUPPORTS_REPLACE_TABLE = False
+    COMMENT_CREATION_TABLE = CommentCreationTable.COMMENT_COMMAND_ONLY
     COMMENT_CREATION_VIEW = CommentCreationView.COMMENT_COMMAND_ONLY
 
     SCHEMA_DIFFER_KWARGS = {}


### PR DESCRIPTION
## Description

Fixes #5969.

`ClickhouseEngineAdapter` sets `COMMENT_CREATION_VIEW` but never `COMMENT_CREATION_TABLE`, so it falls back to the base default `IN_SCHEMA_DEF_CTAS` and embeds `COMMENT '...'` in `CREATE TABLE ... AS SELECT`, which Cloud rejects:

```
Code: 62. DB::Exception: Syntax error: failed at position 198 (COMMENT):
COMMENT 'test table description' AS SELECT ... Expected one of: AS, end of query.
```

Setting it to `COMMENT_COMMAND_ONLY` keeps the comment out of the CTAS and routes the table and column descriptions through the existing `ALTER TABLE ... MODIFY COMMENT` / `... COMMENT COLUMN` paths, same as views already do.

## Test Plan

Heads up: these tests only fail on Cloud. They pass against the Docker ClickHouse behind `make clickhouse-test` both before and after this change (I checked 24.7 and 26.8.1 — both accept the inline `COMMENT`), so I couldn't reproduce the Cloud failure locally.

What I could verify is that the CTAS no longer carries a `COMMENT` at all:

```sql
-- before
CREATE TABLE "t" ENGINE=MergeTree ORDER BY () AS (SELECT ...) COMMENT 'test table description'

-- after
CREATE TABLE "t" ENGINE=MergeTree ORDER BY () AS SELECT ...
ALTER TABLE "t" MODIFY COMMENT 'test table description'
ALTER TABLE "t" COMMENT COLUMN "id" 'test id column description'
```

Since the inline `COMMENT` is gone entirely, its position no longer matters. Leaving the actual Cloud confirmation to the `clickhouse-cloud-test` job here.

Locally: `make clickhouse-test` 168 passed, `make fast-test` 2621 passed, `make style` clean.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable) — none added; the two existing tests in #5969 cover it
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
