### PR TITLE
fix(test): support out-of-nanosecond-range timestamps in unit test comparisons

### DIFF
--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -263,12 +263,9 @@ class ModelTest(unittest.TestCase):
         for col, value in object_sentinel_values.items():
             try:
                 # can't use `isinstance()` here - https://stackoverflow.com/a/68743663/1707525
-                if type(value) is datetime.date:
-                    expected[col] = pd.to_datetime(expected[col]).dt.date
-                elif type(value) is datetime.time:
-                    expected[col] = pd.to_datetime(expected[col]).dt.time
-                elif type(value) is datetime.datetime:
-                    expected[col] = pd.to_datetime(expected[col]).dt.to_pydatetime()
+                value_type = type(value)
+                if value_type in (datetime.date, datetime.time, datetime.datetime):
+                    expected[col] = _parse_expected_datetime_column(expected[col], value_type)
             except Exception as e:
                 from sqlmesh.core.console import get_console
 
@@ -1012,6 +1009,30 @@ def _raise_error(msg: str, path: Path | None = None) -> None:
     if path:
         raise TestError(f"Failed to run test at {path}:\n{msg}")
     raise TestError(f"Failed to run test:\n{msg}")
+
+
+def _parse_expected_datetime_column(series: pd.Series, target_type: type) -> pd.Series:
+    """Convert a series of expected values to python ``date``/``time``/``datetime``.
+
+    Falls back to microsecond resolution when pandas' default nanosecond
+    parsing overflows. SQL ``TIMESTAMP`` columns can carry values outside
+    pandas' default ``datetime64[ns]`` range (1677-09-21..2262-04-11), so
+    unit tests may compare against values like ``0001-01-01`` which are
+    valid in the database but overflow the default resolution.
+    """
+    import pandas as pd
+    from pandas.errors import OutOfBoundsDatetime
+
+    try:
+        parsed = pd.to_datetime(series)
+    except OutOfBoundsDatetime:
+        parsed = series.astype("datetime64[us]")
+
+    if target_type is datetime.date:
+        return parsed.dt.date
+    if target_type is datetime.time:
+        return parsed.dt.time
+    return parsed.dt.to_pydatetime()
 
 
 def _normalize_df_value(value: t.Any) -> t.Any:

--- a/sqlmesh/core/test/definition.py
+++ b/sqlmesh/core/test/definition.py
@@ -1032,7 +1032,11 @@ def _parse_expected_datetime_column(series: pd.Series, target_type: type) -> pd.
         return parsed.dt.date
     if target_type is datetime.time:
         return parsed.dt.time
-    return parsed.dt.to_pydatetime()
+    # `Series.dt.to_pydatetime()` returns an `ndarray` in pandas 2.x. Wrap it in a
+    # Series with ``dtype=object`` so pandas does not coerce the values back to
+    # ``pd.Timestamp`` (which would reintroduce the nanosecond overflow this
+    # function exists to avoid).
+    return pd.Series(parsed.dt.to_pydatetime(), index=parsed.index, dtype="object")
 
 
 def _normalize_df_value(value: t.Any) -> t.Any:

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2931,6 +2931,46 @@ def test_timestamp_normalization() -> None:
     )
 
 
+def test_out_of_bounds_nanosecond_timestamp_comparison(mocker: MockerFixture) -> None:
+    # https://github.com/TobikoData/sqlmesh/issues/5929
+    # Engines like Redshift may return a TIMESTAMP column as an object-dtype
+    # series of python `datetime.datetime` instances. Values outside pandas'
+    # default `datetime64[ns]` range (1677-09-21..2262-04-11) - which SQL
+    # `TIMESTAMP` fully supports - previously raised `OutOfBoundsDatetime`
+    # while parsing the expected values, producing a "Failed to convert
+    # expected value into `datetime`" warning and a false mismatch on values
+    # whose repr survives str-coercion (the values below happen to compare
+    # equal via `str()`, so the mismatch was silent).
+    test = _create_test(
+        body=load_yaml(
+            """
+test_foo:
+  model: sushi.foo
+  outputs:
+    query:
+      - ts_col: "0001-01-01 00:00:00"
+      - ts_col: "9999-12-31 23:59:59"
+            """
+        ),
+        test_name="test_foo",
+        model=_create_model("SELECT ts_col FROM raw"),
+        context=Context(config=Config(model_defaults=ModelDefaultsConfig(dialect="duckdb"))),
+    )
+    actual = pd.DataFrame(
+        {
+            "ts_col": pd.Series(
+                [datetime.datetime(1, 1, 1), datetime.datetime(9999, 12, 31, 23, 59, 59)],
+                dtype=object,
+            )
+        }
+    )
+    expected = pd.DataFrame({"ts_col": ["0001-01-01 00:00:00", "9999-12-31 23:59:59"]})
+    log_warning = mocker.spy(get_console(), "log_warning")
+    test.assert_equal(expected=expected, actual=actual, sort=False)
+    for call_args in log_warning.call_args_list:
+        assert "Failed to convert expected value" not in call_args.args[0]
+
+
 @use_terminal_console
 def test_disable_test_logging_if_no_tests_found(mocker: MockerFixture, tmp_path: Path) -> None:
     init_example_project(tmp_path, engine_type="duckdb")

--- a/tests/core/test_test.py
+++ b/tests/core/test_test.py
@@ -2964,7 +2964,9 @@ test_foo:
             )
         }
     )
-    expected = pd.DataFrame({"ts_col": ["0001-01-01 00:00:00", "9999-12-31 23:59:59"]})
+    # Use T separator so a string-only comparison (broken path) would mismatch
+    # against str(datetime.datetime(1, 1, 1)) == "0001-01-01 00:00:00".
+    expected = pd.DataFrame({"ts_col": ["0001-01-01T00:00:00", "9999-12-31T23:59:59"]})
     log_warning = mocker.spy(get_console(), "log_warning")
     test.assert_equal(expected=expected, actual=actual, sort=False)
     for call_args in log_warning.call_args_list:


### PR DESCRIPTION
## Description

Fixes #5929.

When a database engine returns a TIMESTAMP column as an object-dtype series of python `datetime.datetime` instances (Redshift is the reporter; any engine whose adapter returns object-dtype behaves the same), the unit-test `assert_equal` path parses the YAML expected values through `pd.to_datetime`, which defaults to nanosecond resolution. That resolution is bounded to 1677-09-21..2262-04-11 and overflows on values SQL TIMESTAMP fully supports — the reporter's example `0001-01-01 00:00:00` is a common sentinel value.

The overflow was caught by a broad `except Exception` inside `ModelTest.assert_equal` that logged a `Failed to convert expected value into datetime` warning and left `expected[col]` as the original strings. Two things happened next:
- For values whose repr survives str-coercion (e.g. `datetime.datetime(1, 1, 1)` → `"0001-01-01 00:00:00"`), the downstream `_to_hashable` normalization stringified both sides and the mismatch was **silent** — the test appeared to pass while emitting a warning.
- For values whose repr did not match, `pd.testing.assert_frame_equal` raised, producing a confusing failure with the same warning above it.

This PR extracts the parsing into `_parse_expected_datetime_column` and falls back to `datetime64[us]` resolution on `pd.errors.OutOfBoundsDatetime`. Microsecond resolution covers year 1 through year 294246, matching SQL TIMESTAMP's supported range, and it round-trips cleanly through `.dt.date` / `.dt.time` / `.dt.to_pydatetime()` for all three sentinel value types the caller already dispatches on. The fast path (`pd.to_datetime`) is preserved verbatim for in-range values, so nothing about existing tests changes.

## Test Plan

- Added `test_out_of_bounds_nanosecond_timestamp_comparison` in `tests/core/test_test.py`. It constructs an object-dtype `actual` DataFrame containing `datetime.datetime(1, 1, 1)` and `datetime.datetime(9999, 12, 31, 23, 59, 59)` — one below and one above pandas' default nanosecond range — and asserts (a) `assert_equal` succeeds and (b) no `Failed to convert expected value` warning is emitted. Both conditions are needed because the pre-fix code path silently mismatched on these particular values.
- Verified the test fails on unpatched `main` (the assertion on `log_warning` fires) and passes on this branch.
- `pytest tests/core/test_test.py` — 76 passed, 1 deselected (`test_pyspark_python_model`; environment lacks a Java runtime, unrelated to this change).
- `ruff check` and `ruff format --check` clean on both changed files. `mypy sqlmesh/core/test/definition.py` clean.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)