### PR TITLE
fix: write file cache entries atomically to avoid read races

### DIFF
--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import gzip
 import logging
+import os
 import pickle
 import shutil
+import tempfile
 import typing as t
 from pathlib import Path
 
@@ -125,8 +127,25 @@ class FileCache(t.Generic[T]):
         if not self._path.is_dir():
             raise SQLMeshError(f"Cache path '{self._path}' is not a directory.")
 
-        with gzip.open(self._cache_entry_path(name, entry_id), "wb", compresslevel=1) as fd:
-            pickle.dump(value, fd)
+        # Write to a temporary file and then atomically move it into place. Writing the
+        # entry in place ("wb" truncates the target file first) means that a concurrent
+        # reader (e.g. another pytest-xdist worker) could observe a partially written
+        # entry and fail to unpickle it.
+        tmp_fd, tmp_name = tempfile.mkstemp(dir=self._path, prefix=f"{self._cache_version}__tmp")
+        try:
+            with os.fdopen(tmp_fd, "wb") as raw_fd:
+                with gzip.open(raw_fd, "wb", compresslevel=1) as fd:
+                    pickle.dump(value, fd)
+            os.replace(tmp_name, self._cache_entry_path(name, entry_id))
+        except OSError as ex:
+            # Storing an entry is best-effort; e.g. on Windows os.replace fails if a
+            # concurrent reader still has the target file open.
+            logger.warning("Failed to store a cache entry '%s': %s", name, ex)
+        finally:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
 
     def exists(self, name: str, entry_id: str = "") -> bool:
         """Returns true if the cache entry with the given name and ID exists, false otherwise.

--- a/sqlmesh/utils/cache.py
+++ b/sqlmesh/utils/cache.py
@@ -136,11 +136,11 @@ class FileCache(t.Generic[T]):
             with os.fdopen(tmp_fd, "wb") as raw_fd:
                 with gzip.open(raw_fd, "wb", compresslevel=1) as fd:
                     pickle.dump(value, fd)
-            os.replace(tmp_name, self._cache_entry_path(name, entry_id))
-        except OSError as ex:
-            # Storing an entry is best-effort; e.g. on Windows os.replace fails if a
-            # concurrent reader still has the target file open.
-            logger.warning("Failed to store a cache entry '%s': %s", name, ex)
+            try:
+                os.replace(tmp_name, self._cache_entry_path(name, entry_id))
+            except OSError as ex:
+                # Windows os.replace fails if a concurrent reader still has the target file open.
+                logger.warning("Failed to store a cache entry '%s': %s", name, ex)
         finally:
             try:
                 os.unlink(tmp_name)

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -42,6 +42,22 @@ def test_file_cache(tmp_path: Path, mocker: MockerFixture):
     assert "客户数据" in cache._cache_entry_path("客户数据").name
 
 
+def test_file_cache_put_is_atomic(tmp_path: Path, mocker: MockerFixture) -> None:
+    cache: FileCache[_TestEntry] = FileCache(tmp_path)
+
+    old_entry = _TestEntry(value="old")
+    cache.put("test_name", value=old_entry)
+
+    # Simulate os.replace failing, e.g. on Windows when a concurrent reader still has the
+    # target file open. The existing entry must never be truncated / partially overwritten.
+    mocker.patch("sqlmesh.utils.cache.os.replace", side_effect=PermissionError("file in use"))
+    cache.put("test_name", value=_TestEntry(value="new"))
+
+    assert cache.get("test_name") == old_entry
+    # The temporary file should have been cleaned up.
+    assert len(list(tmp_path.glob("*"))) == 1
+
+
 def test_optimized_query_cache(tmp_path: Path, mocker: MockerFixture):
     model = SqlModel(
         name="test_model",


### PR DESCRIPTION
## Description

Fixes #6010

`FileCache.put` opened the cache entry with `"wb"`, which truncates the file in place before the gzip/pickle write completes. A concurrent reader (e.g. another pytest-xdist worker sharing the cache directory) can open the file inside that window and hit `pickle.load` EOF ("Ran out of input"), which is what intermittently broke `tests/lsp/test_reference_macro_find_all.py::test_multi_repo_macro_references` on Windows CI.

This change writes the payload to a temp file in the same cache directory and `os.replace`s it onto the entry path, so readers only ever observe complete entries. Details:

- The temp file is prefixed with the cache version so the stale-file cleanup in `FileCache.__init__` doesn't unlink it mid-write (fresh atime keeps it alive; orphaned temp files from a crashed process still get cleaned up by the atime threshold).
- The store is best-effort: on Windows `os.replace` fails with a sharing violation if a reader still has the target open. In that case we log a warning and keep the existing intact entry rather than raising (mirroring how `get` handles unreadable entries).

I didn't add the optional `get` retry from the issue — `get` already swallows unpickling errors and `get_or_load` falls back to the loader, and with atomic writes a partial read can no longer happen.

## Test Plan

- Added `test_file_cache_put_is_atomic`, which verifies that a failed `os.replace` leaves the existing entry untouched and cleans up the temp file.
- `pytest tests/utils/test_cache.py` passes.
- Stress-checked with 2 readers looping `get` against a writer looping `put` on the same entry: on `main` this produced ~2900 failed reads (partial file -> unpickle EOF); with this change, 0.

## Checklist

- [x] I have run `make style` and fixed any issues (ruff check, ruff format and mypy are clean on the touched files)
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (ran `tests/utils`; remaining `fast-test` failures in my env are missing optional engine deps, unrelated to this change)
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://github.com/SQLMesh/sqlmesh/blob/main/DCO)
