### PR TITLE
fix: Simplify Java Installation in DevContainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -10,11 +10,6 @@
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
       "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
     },
-    "ghcr.io/devcontainers/features/java:1": {
-      "version": "1.8.1",
-      "resolved": "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48",
-      "integrity": "sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48"
-    },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "1.8.0",
       "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,6 @@
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
     },
-    "ghcr.io/devcontainers/features/java:1": {
-      "version": "21"
-    },
     "ghcr.io/devcontainers/features/docker-in-docker:4": {}
   },
   "postCreateCommand": "bash .devcontainer/post-create-command.sh",

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -20,7 +20,7 @@ else
     rm packages-microsoft-prod.deb
 fi
 
-ALL_DEPENDENCIES="libpq-dev netcat-traditional unixodbc-dev default-jdk msodbcsql18"
+ALL_DEPENDENCIES="libpq-dev netcat-traditional unixodbc-dev default-jdk msodbcsql18 msopenjdk-21"
 sudo apt-get clean && sudo apt-get -y update && sudo ACCEPT_EULA='Y' apt-get -y install $ALL_DEPENDENCIES
 
 # Install Python dependencies

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -20,7 +20,7 @@ else
     rm packages-microsoft-prod.deb
 fi
 
-ALL_DEPENDENCIES="libpq-dev netcat-traditional unixodbc-dev default-jdk msodbcsql18 msopenjdk-21"
+ALL_DEPENDENCIES="libpq-dev netcat-traditional unixodbc-dev default-jdk msodbcsql18"
 sudo apt-get clean && sudo apt-get -y update && sudo ACCEPT_EULA='Y' apt-get -y install $ALL_DEPENDENCIES
 
 # Install Python dependencies


### PR DESCRIPTION
## Description

An apparent breaking change in the SDKMAN! API caused the Java DevContainer feature to fail to install.

This change removes that feature and instead installs Java via the `msopenjdk-21` package.

An alternate solution would have been to update the DevContainer feature, however this method appeared more robust against future changes.

## Test Plan

Dev Container successfully builds and all tests run by `make fast-test` succeed.

A caveat - the test `tests/core/test_context.py::test_python_model_empty_df_raises` fails when run in parallel, but passes when run sequentially. I believe this is unrelated to this change and I am fixing in PR #6013.

## Checklist

- [x] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable) (N/A)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
