### PR TITLE
fix: Resolve test collisions when capsys used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ slow-test:
 	pytest -n auto -m "(fast or slow) and not cicdonly and not isolated" && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
 
 cicd-test:
-	pytest -n auto -m "(fast or slow) and not pyspark and not isolated" --junitxml=test-results/junit-cicd.xml && pytest -m "pyspark" && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
+	pytest -n auto -m "(fast or slow) and not pyspark and not isolated" --junitxml=test-results/junit-cicd.xml && pytest -m "pyspark" && pytest -m "isolated and not pyspark" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
 
 core-fast-test:
 	pytest -n auto -m "fast and not web and not github and not dbt and not jupyter"

--- a/Makefile
+++ b/Makefile
@@ -132,13 +132,13 @@ engine-up: engine-clickhouse-up engine-mssql-up engine-mysql-up engine-postgres-
 engine-down: engine-clickhouse-down engine-mssql-down engine-mysql-down engine-postgres-down engine-spark-down engine-trino-down
 
 fast-test:
-	pytest -n auto -m "fast and not cicdonly" --junitxml=test-results/junit-fast-test.xml && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
+	pytest -n auto -m "fast and not cicdonly and not isolated" --junitxml=test-results/junit-fast-test.xml && pytest -m "isolated and not slow" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
 
 slow-test:
-	pytest -n auto -m "(fast or slow) and not cicdonly" && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
+	pytest -n auto -m "(fast or slow) and not cicdonly and not isolated" && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
 
 cicd-test:
-	pytest -n auto -m "(fast or slow) and not pyspark" --junitxml=test-results/junit-cicd.xml && pytest -m "pyspark" && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
+	pytest -n auto -m "(fast or slow) and not pyspark and not isolated" --junitxml=test-results/junit-cicd.xml && pytest -m "pyspark" && pytest -m "isolated" && pytest -m "registry_isolation" && pytest -m "dialect_isolated"
 
 core-fast-test:
 	pytest -n auto -m "fast and not web and not github and not dbt and not jupyter"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,8 +216,12 @@ def pytest_collection_modifyitems(items, *args, **kwargs):
             if marker.name in test_type_markers:
                 break
         else:
-            # if no test type marker is found, assume fast test
-            item.add_marker("fast")
+            # If no test type marker is found, assume it is a fast or isolated test.
+            if "capsys" in item.fixturenames:
+                # capsys is not threadsafe, so the test must be isolated.
+                item.add_marker("isolated")
+            else:
+                item.add_marker("fast")
 
 
 # Ignore all local config files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,16 +212,14 @@ def pytest_collection_modifyitems(items, *args, **kwargs):
         "dialect_isolated",
     }
     for item in items:
+        if "capsys" in item.fixturenames:
+            # capsys is not threadsafe, so the test must be isolated.
+            item.add_marker("isolated")
         for marker in item.iter_markers():
             if marker.name in test_type_markers:
                 break
         else:
-            # If no test type marker is found, assume it is a fast or isolated test.
-            if "capsys" in item.fixturenames:
-                # capsys is not threadsafe, so the test must be isolated.
-                item.add_marker("isolated")
-            else:
-                item.add_marker("fast")
+            item.add_marker("fast")
 
 
 # Ignore all local config files


### PR DESCRIPTION
## Description

Tests that use capsys can collide with each other as capsys is not threadsafe.

I have modified `conftest.py` to apply the `isolated` pytest marker (so they tests run sequentially) if `capsys` is passed to the test.

## Test Plan

- `make fast-test` passes.
- PyTest correctly flags tests that use capsys as marked with `isolated`:

<img width="672" height="435" alt="image" src="https://github.com/user-attachments/assets/32effb0b-0c26-4e8c-a6f1-c452d787ec33" />

  Note that `test_python_model_empty_df_raises` does not have the `isolated` marker applied to it directly, it is dynamically added by the changes to conftest.

  <img width="716" height="314" alt="image" src="https://github.com/user-attachments/assets/f4c347d2-c337-4ba9-beb0-f97231599fa3" />



## Checklist

- [x] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable) (N/A)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
