### PR TITLE
perf: selective snapshot hydration

### DIFF
--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -753,10 +753,12 @@ class GenericContext(BaseContext, t.Generic[C]):
                 # Only hydrate names which are absent locally. These can be deleted nodes from
                 # this project or nodes from another project which must be merged into the
                 # context. The project field on the hydrated node disambiguates the two cases.
-                local_node_names = {*self._models, *self._standalone_audits}
                 remote_snapshot_infos = []
                 for snapshot_info in prod.snapshots:
-                    if snapshot_info.name in local_node_names:
+                    local_store = (
+                        self._standalone_audits if snapshot_info.is_audit else self._models
+                    )
+                    if snapshot_info.name in local_store:
                         uncached.add(snapshot_info.name)
                     else:
                         remote_snapshot_infos.append(snapshot_info)

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -745,7 +745,23 @@ class GenericContext(BaseContext, t.Generic[C]):
             prod = self.state_reader.get_environment(c.PROD)
 
             if prod:
-                for snapshot in self.state_reader.get_snapshots(prod.snapshots).values():
+                # Environment snapshot infos already contain the names we need to distinguish
+                # local nodes from nodes owned by another project. Hydrating local snapshots
+                # here is wasteful: their payloads are not used, and a large remote state can
+                # spend most of Context.load() decoding those model object graphs.
+                #
+                # Only hydrate names which are absent locally. These can be deleted nodes from
+                # this project or nodes from another project which must be merged into the
+                # context. The project field on the hydrated node disambiguates the two cases.
+                local_node_names = {*self._models, *self._standalone_audits}
+                remote_snapshot_infos = []
+                for snapshot_info in prod.snapshots:
+                    if snapshot_info.name in local_node_names:
+                        uncached.add(snapshot_info.name)
+                    else:
+                        remote_snapshot_infos.append(snapshot_info)
+
+                for snapshot in self.state_reader.get_snapshots(remote_snapshot_infos).values():
                     if snapshot.node.project in self._projects:
                         uncached.add(snapshot.name)
                     else:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -277,6 +277,34 @@ def test_render_seed_model(sushi_context, assert_exp_eq):
 
 
 @pytest.mark.slow
+def test_load_only_hydrates_remote_snapshots_missing_locally(sushi_context: Context) -> None:
+    prod = sushi_context.state_reader.get_environment("prod")
+    assert prod is not None
+
+    local_node_names = {*sushi_context.models, *sushi_context.standalone_audits}
+    expected_remote_names = {
+        snapshot_info.name
+        for snapshot_info in prod.snapshots
+        if snapshot_info.name not in local_node_names
+    }
+    assert len(expected_remote_names) < len(prod.snapshots)
+
+    with patch.object(
+        sushi_context.state_reader,
+        "get_snapshots",
+        wraps=sushi_context.state_reader.get_snapshots,
+    ) as get_snapshots_mock:
+        sushi_context.load(update_schemas=False)
+
+    load_snapshot_names = {
+        snapshot_info.name
+        for call_args in get_snapshots_mock.call_args_list
+        for snapshot_info in call_args.args[0]
+    }
+    assert load_snapshot_names == expected_remote_names
+
+
+@pytest.mark.slow
 def test_diff(sushi_context: Context, mocker: MockerFixture):
     mock_console = mocker.Mock()
     sushi_context.console = mock_console

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -17,6 +17,7 @@ from sqlglot.errors import SchemaError
 
 import sqlmesh.core.constants
 from sqlmesh.cli.project_init import init_example_project
+from sqlmesh.core.audit import StandaloneAudit
 from sqlmesh.core.console import TerminalConsole
 from sqlmesh.core import dialect as d, constants as c
 from sqlmesh.core.config import (
@@ -280,6 +281,7 @@ def test_render_seed_model(sushi_context, assert_exp_eq):
 def test_load_only_hydrates_remote_snapshots_missing_locally(sushi_context: Context) -> None:
     prod = sushi_context.state_reader.get_environment("prod")
     assert prod is not None
+    sushi_context._projects = {"local_project"}
 
     local_node_names = {*sushi_context.models, *sushi_context.standalone_audits}
     expected_remote_names = {
@@ -302,6 +304,49 @@ def test_load_only_hydrates_remote_snapshots_missing_locally(sushi_context: Cont
         for snapshot_info in call_args.args[0]
     }
     assert load_snapshot_names == expected_remote_names
+
+
+@pytest.mark.slow
+def test_load_hydrates_opposite_type_snapshot_name_collision(
+    sushi_context: Context, make_snapshot: t.Callable
+) -> None:
+    prod = sushi_context.state_reader.get_environment("prod")
+    assert prod is not None
+    sushi_context._projects = {"local_project"}
+
+    local_model = next(iter(sushi_context.models.values()))
+    remote_audit_snapshot = make_snapshot(
+        StandaloneAudit(
+            name=local_model.fqn,
+            query=parse_one("SELECT NULL LIMIT 0"),
+            project="remote_project",
+        )
+    )
+    remote_audit_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    prod_with_collision = prod.copy(
+        update={"snapshots_": [*prod.snapshots, remote_audit_snapshot.table_info]}
+    )
+
+    with (
+        patch.object(
+            sushi_context.state_reader,
+            "get_environment",
+            return_value=prod_with_collision,
+        ),
+        patch.object(
+            sushi_context.state_reader,
+            "get_snapshots",
+            wraps=sushi_context.state_reader.get_snapshots,
+        ) as get_snapshots_mock,
+    ):
+        sushi_context.load(update_schemas=False)
+
+    requested_snapshot_names = {
+        snapshot_info.name
+        for call_args in get_snapshots_mock.call_args_list
+        for snapshot_info in call_args.args[0]
+    }
+    assert remote_audit_snapshot.name in requested_snapshot_names
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Description

Avoids hydrating production snapshot payloads for models and standalone audits already defined in the local project.

Previously, `Context.load()` hydrated every snapshot in the production environment to determine whether each node belonged to the current project or another project. The environment's compact snapshot metadata already contains the snapshot names needed to identify locally defined nodes.

This change:

- Marks locally defined production snapshot names as uncached using compact environment metadata.
- Hydrates only snapshot names absent from the local project.
- Continues hydrating missing names so deleted local nodes and cross-project nodes can be distinguished using the snapshot's project metadata.
- Preserves cross-project state merging and existing schema reconstruction behavior.
- Applies independently of project-index loading.

This primarily reduces Python-side snapshot deserialization and object hydration for projects with large production environments.

## Test Plan

Live env (400 models)
plan1	40.17s <--> 33.16s	7.00s faster, 17.4%
plan2 41.41s <-->  33.36s	8.05s faster, 19.4%
plan3 38.41s <--> 32.48s	5.93s faster, 15.4%
average	40.00s <--> 33.00s	7.00s faster, 17.5%

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://github.com/SQLMesh/sqlmesh/pull/DCO)