### PR TITLE
fix(mssql): skip dbo on drop schema

### DIFF
--- a/sqlmesh/core/engine_adapter/mssql.py
+++ b/sqlmesh/core/engine_adapter/mssql.py
@@ -180,7 +180,10 @@ class MSSQLEngineAdapter(
         **drop_args: t.Dict[str, exp.Expr],
     ) -> None:
         """
-        MsSql doesn't support CASCADE clause and drops schemas unconditionally.
+        MsSql doesn't support CASCADE clause so objects are dropped individually.
+
+        SQL Server also forbids dropping the built-in ``dbo`` schema (error 15150).
+        Objects inside it are still dropped when cascade=True, but the schema itself is left in place.
         """
         if cascade:
             objects = self._get_data_objects(schema_name)
@@ -199,6 +202,11 @@ class MSSQLEngineAdapter(
                         object_table,
                         exists=ignore_if_not_exists,
                     )
+
+        schema = schema_name.db if isinstance(schema_name, exp.Table) else schema_name
+        if schema.lower() == "dbo":
+            return
+
         super().drop_schema(schema_name, ignore_if_not_exists=ignore_if_not_exists, cascade=False)
 
     def merge(

--- a/tests/core/engine_adapter/test_mssql.py
+++ b/tests/core/engine_adapter/test_mssql.py
@@ -714,6 +714,26 @@ def test_drop_schema(make_mocked_engine_adapter: t.Callable):
     ]
 
 
+def test_drop_schema_skips_dbo(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
+
+    adapter._get_data_objects = mock.Mock()
+    adapter._get_data_objects.return_value = [
+        DataObject(
+            catalog="test_catalog",
+            schema="dbo",
+            name="test_view",
+            type=DataObjectType.from_str("VIEW"),
+        )
+    ]
+
+    adapter.drop_schema("dbo", cascade=True)
+
+    sql_calls = to_sql_calls(adapter)
+    assert """DROP VIEW IF EXISTS [dbo].[test_view];""" in sql_calls
+    assert """DROP SCHEMA IF EXISTS [dbo];""" not in sql_calls
+
+
 def test_drop_schema_with_special_identifiers(make_mocked_engine_adapter: t.Callable):
     adapter = make_mocked_engine_adapter(MSSQLEngineAdapter)
 


### PR DESCRIPTION
## Description

Closes https://github.com/SQLMesh/sqlmesh/issues/4833

SQL Server does not allow the dropping of the `dbo` schema. Skipping for drop_schema method.

## Test Plan

New Test: `test_drop_schema_skips_dbo`

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
