### PR TITLE
ci: add dbt 1.12 to test matrix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -457,7 +457,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
+        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10', '1.12']
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ install-dev-dbt-%:
 	echo "Installing dbt version: $$version"; \
 	cp pyproject.toml pyproject.toml.backup; \
 	$(SED_INPLACE) 's/"pydantic>=2.0.0"/"pydantic"/g' pyproject.toml; \
-	if [ "$$version" = "1.10.0" ]; then \
-		echo "Applying special handling for dbt 1.10.0"; \
+	if [ "$$version" = "1.10.0" ] || [ "$$version" = "1.12.0" ]; then \
+		echo "Applying special handling for dbt $$version"; \
 		$(SED_INPLACE) -E 's/"(dbt-core)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \
 		$(SED_INPLACE) -E 's/"(dbt-(bigquery|duckdb|snowflake|athena-community|clickhouse|redshift|trino))[^"]*"/"\1"/g' pyproject.toml; \
 		$(SED_INPLACE) -E 's/"(dbt-databricks)[^"]*"/"\1~='"$$version"'"/g' pyproject.toml; \


### PR DESCRIPTION
## Description

Adds dbt 1.12 to the `test-dbt-versions` CI matrix (#5993). `dbt-duckdb` has no `1.12.0` release on PyPI yet, so `install-dev-dbt-%` in the Makefile now routes `1.12.0` through the same special-case handling as `1.10.0`: pins only `dbt-core`/`dbt-databricks`, leaves other adapters (`dbt-bigquery`, `dbt-duckdb`, `dbt-snowflake`, `dbt-athena-community`, `dbt-clickhouse`,
`dbt-redshift`, `dbt-trino`) unpinned so the resolver can pick a compatible version.

Fixes #5993

## Test Plan

Verified locally (WSL Ubuntu):
- `UV=1 make install-dev-dbt-1.12` succeeds
- `make dbt-fast-test` → 88 passed, 0 failed
- `sqlmesh info --skip-connection` in `examples/sushi_dbt` loads the project successfully under dbt-core 1.12.3

## Checklist

- [x] I have run `make style` and fixed any issues
- [ ] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)