### PR TITLE
fix(snowflake): use ALTER ICEBERG TABLE to register column comments on Iceberg tables

### DIFF
--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -833,7 +833,9 @@ class EngineAdapter:
             and self.COMMENT_CREATION_TABLE.is_comment_command_only
             and self.comments_enabled
         ):
-            self._create_column_comments(table_name, column_descriptions)
+            self._create_column_comments(
+                table_name, column_descriptions, table_format=kwargs.get("table_format")
+            )
 
     def _build_schema_exp(
         self,
@@ -990,7 +992,9 @@ class EngineAdapter:
         ):
             self._create_table_comment(table_name, table_description)
         if column_descriptions and schema is None and self.comments_enabled:
-            self._create_column_comments(table_name, column_descriptions)
+            self._create_column_comments(
+                table_name, column_descriptions, table_format=kwargs.get("table_format")
+            )
 
     def _create_table(
         self,
@@ -3058,7 +3062,18 @@ class EngineAdapter:
         column_comments: t.Dict[str, str],
         table_kind: str = "TABLE",
         materialized_view: bool = False,
+        table_format: t.Optional[str] = None,
     ) -> None:
+        """Registers column comments with a post-creation command.
+
+        Args:
+            table_name: The name of the table or view.
+            column_comments: Mapping between the column name and its comment.
+            table_kind: The kind of object being commented on, `TABLE` or `VIEW`.
+            materialized_view: Whether the view is materialized.
+            table_format: The table format of the table, if any. Engines that require
+                format-specific DDL to alter a table use it to derive `table_kind`.
+        """
         table = exp.to_table(table_name)
 
         for col, comment in column_comments.items():

--- a/sqlmesh/core/engine_adapter/bigquery.py
+++ b/sqlmesh/core/engine_adapter/bigquery.py
@@ -818,6 +818,7 @@ class BigQueryEngineAdapter(ClusteredByMixin, RowDiffMixin, GrantsFromInfoSchema
         column_comments: t.Dict[str, str],
         table_kind: str = "TABLE",
         materialized_view: bool = False,
+        table_format: t.Optional[str] = None,
     ) -> None:
         if not (table_kind == "VIEW" and materialized_view):
             table = self._get_table(table_name)

--- a/sqlmesh/core/engine_adapter/mysql.py
+++ b/sqlmesh/core/engine_adapter/mysql.py
@@ -131,6 +131,7 @@ class MySQLEngineAdapter(
         column_comments: t.Dict[str, str],
         table_kind: str = "TABLE",
         materialized_view: bool = False,
+        table_format: t.Optional[str] = None,
     ) -> None:
         table = exp.to_table(table_name)
         table_sql = table.sql(dialect=self.dialect, identify=True)

--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -632,12 +632,19 @@ class SnowflakeEngineAdapter(
         column_comments: t.Dict[str, str],
         table_kind: str = "TABLE",
         materialized_view: bool = False,
+        table_format: t.Optional[str] = None,
     ) -> None:
         """
         Reference: https://docs.snowflake.com/en/sql-reference/sql/alter-table-column#syntax
+        Reference: https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table#syntax
         """
         if not column_comments:
             return
+
+        # Snowflake rejects `ALTER TABLE` for Iceberg tables, it requires
+        # `ALTER ICEBERG TABLE` instead
+        if table_format and table_kind == "TABLE":
+            table_kind = f"{table_format.upper()} TABLE"
 
         table = exp.to_table(table_name)
         table_sql = self._to_sql(table)

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -246,6 +246,38 @@ def test_multiple_column_comments(make_mocked_engine_adapter: t.Callable, mocker
     ]
 
 
+def test_column_comments_iceberg(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+
+    adapter._create_column_comments(
+        "test_table",
+        {"a": "a column description", "b": "b column description"},
+        table_format="iceberg",
+    )
+
+    assert to_sql_calls(adapter) == [
+        """ALTER ICEBERG TABLE "test_table" ALTER COLUMN "a" COMMENT 'a column description', COLUMN "b" COMMENT 'b column description'""",
+    ]
+
+
+def test_ctas_column_comments_iceberg(make_mocked_engine_adapter: t.Callable):
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+
+    # The column types are unknown, so the comments can't be inlined into the CTAS
+    # schema definition and are registered with a post-creation ALTER instead
+    adapter.ctas(
+        "test_table",
+        parse_one("SELECT a, b FROM source_table"),
+        table_format="iceberg",
+        column_descriptions={"a": "a column description"},
+    )
+
+    assert to_sql_calls(adapter) == [
+        """CREATE ICEBERG TABLE IF NOT EXISTS "test_table" AS SELECT "a", "b" FROM "source_table\"""",
+        """ALTER ICEBERG TABLE "test_table" ALTER COLUMN "a" COMMENT 'a column description'""",
+    ]
+
+
 def test_sync_grants_config(make_mocked_engine_adapter: t.Callable, mocker: MockerFixture):
     adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
     relation = normalize_identifiers(


### PR DESCRIPTION
Follow-up to #5722, related to #5721.

Snowflake rejects `ALTER TABLE` for Iceberg tables and requires `ALTER ICEBERG TABLE` instead. `SnowflakeEngineAdapter._create_column_comments` builds its statement with a hardcoded `TABLE` kind, so registering column comments on an Iceberg table with a post-creation command emits:

```sql
ALTER TABLE "t" ALTER COLUMN "a" COMMENT '...'
```

The call is wrapped in `try/except`, so the plan does not fail: the comments are silently dropped and a warning misattributes the failure to limited permissions.

This path is only taken when the comments cannot be inlined into the CTAS schema definition, i.e. when the column types are not fully known. When the types are known, the comments are part of the `CREATE ICEBERG TABLE` statement and are registered correctly.

## Changes

- `EngineAdapter._create_column_comments` accepts `table_format`, mirroring the `_create_table` convention, and the base adapter passes it from the two table creation paths (`create_table` and `_create_table_from_source_queries`).
- `SnowflakeEngineAdapter._create_column_comments` derives the Iceberg-specific kind from it, only when the kind is `TABLE`, so views are unaffected:

  ```sql
  ALTER ICEBERG TABLE "t" ALTER COLUMN "a" COMMENT '...'
  ```

- The MySQL and BigQuery overrides gain the same parameter so their signatures stay compatible with the base class; they do not use it.

Reference: https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table#syntax (`{ ALTER | MODIFY } [ COLUMN ] <col_name> COMMENT '<string>'`, comma-separated for multiple columns).

## Tests

- `test_column_comments_iceberg`: a direct call emits `ALTER ICEBERG TABLE ... ALTER COLUMN ... COMMENT ...` for multiple columns.
- `test_ctas_column_comments_iceberg`: an end-to-end `ctas` with unknown column types emits `CREATE ICEBERG TABLE ... AS SELECT ...` followed by the `ALTER ICEBERG TABLE` comment statement.

The generated DDL is verified at unit level against the documented syntax; it has not been validated against a live Snowflake account.
