### PR TITLE
fix(test): create ModelTests before concurrent pool workers

### DIFF
--- a/sqlmesh/core/test/runner.py
+++ b/sqlmesh/core/test/runner.py
@@ -125,9 +125,11 @@ def run_tests(
     # Ensure workers are not greater than the number of tests
     num_workers = min(len(model_test_metadata) or 1, default_test_connection.concurrent_tasks)
 
-    def _run_single_test(
-        metadata: ModelTestMetadata, engine_adapter: EngineAdapter
-    ) -> t.Optional[ModelTextTestResult]:
+    # Build ModelTest instances on the calling thread before workers start. create_test()
+    # can call to_datetime() / ttl_cache (time.time()), which races with another worker's
+    # time_machine freeze when execution_time is set under concurrent_tasks > 1.
+    tests: list[ModelTest] = []
+    for metadata, engine_adapter in metadata_to_adapter.items():
         test = ModelTest.create_test(
             body=metadata.body,
             test_name=metadata.test_name,
@@ -140,10 +142,10 @@ def run_tests(
             concurrency=num_workers > 1,
             verbosity=verbosity,
         )
+        if test:
+            tests.append(test)
 
-        if not test:
-            return None
-
+    def _run_single_test(test: ModelTest) -> ModelTextTestResult:
         result = t.cast(
             ModelTextTestResult,
             ModelTextTestRunner().run(t.cast(unittest.TestCase, test)),
@@ -159,10 +161,7 @@ def run_tests(
     start_time = time.perf_counter()
     try:
         with ThreadPoolExecutor(max_workers=num_workers) as pool:
-            futures = [
-                pool.submit(_run_single_test, metadata=metadata, engine_adapter=engine_adapter)
-                for metadata, engine_adapter in metadata_to_adapter.items()
-            ]
+            futures = [pool.submit(_run_single_test, test) for test in tests]
 
             for future in concurrent.futures.as_completed(futures):
                 test_results.append(future.result())

--- a/sqlmesh/core/test/runner.py
+++ b/sqlmesh/core/test/runner.py
@@ -125,26 +125,6 @@ def run_tests(
     # Ensure workers are not greater than the number of tests
     num_workers = min(len(model_test_metadata) or 1, default_test_connection.concurrent_tasks)
 
-    # Build ModelTest instances on the calling thread before workers start. create_test()
-    # can call to_datetime() / ttl_cache (time.time()), which races with another worker's
-    # time_machine freeze when execution_time is set under concurrent_tasks > 1.
-    tests: list[ModelTest] = []
-    for metadata, engine_adapter in metadata_to_adapter.items():
-        test = ModelTest.create_test(
-            body=metadata.body,
-            test_name=metadata.test_name,
-            models=models,
-            engine_adapter=engine_adapter,
-            dialect=dialect,
-            path=metadata.path,
-            default_catalog=default_catalog,
-            preserve_fixtures=preserve_fixtures,
-            concurrency=num_workers > 1,
-            verbosity=verbosity,
-        )
-        if test:
-            tests.append(test)
-
     def _run_single_test(test: ModelTest) -> ModelTextTestResult:
         result = t.cast(
             ModelTextTestResult,
@@ -160,6 +140,28 @@ def run_tests(
 
     start_time = time.perf_counter()
     try:
+        # Build ModelTest instances on the calling thread before workers start. create_test()
+        # can call to_datetime() / ttl_cache (time.time()), which races with another worker's
+        # time_machine freeze when execution_time is set under concurrent_tasks > 1.
+        # NOTE: We can run create_tests in a separate parallel stage for a future optimization.
+        # We just can't overlap runs/creations.
+        tests: list[ModelTest] = []
+        for metadata, engine_adapter in metadata_to_adapter.items():
+            test = ModelTest.create_test(
+                body=metadata.body,
+                test_name=metadata.test_name,
+                models=models,
+                engine_adapter=engine_adapter,
+                dialect=dialect,
+                path=metadata.path,
+                default_catalog=default_catalog,
+                preserve_fixtures=preserve_fixtures,
+                concurrency=num_workers > 1,
+                verbosity=verbosity,
+            )
+            if test:
+                tests.append(test)
+
         with ThreadPoolExecutor(max_workers=num_workers) as pool:
             futures = [pool.submit(_run_single_test, test) for test in tests]
 


### PR DESCRIPTION
## Summary

When `sqlmesh test` runs with `concurrent_tasks > 1` and a unit test sets `vars.execution_time`, `ModelTest.create_test()` was running on worker threads. That path can call `to_datetime()` / `ttl_cache` (`time.time()`) while another worker is starting or stopping a `time_machine` freeze, which produces `IndexError: list index out of range` (or similar) during test creation.

This moves `ModelTest.create_test()` onto the calling thread before submitting work to the pool. Workers only run the already-built tests. Creation stays inside the same try/finally that closes engine adapters so an invalid `create_test` still cleans up connections.

Fixes #6039

## Test plan

- [x] `pytest tests/core/test_test.py::test_freeze_time_concurrent -v` passed 20 consecutive times locally (race; single pass is not enough)
- [ ] CI green

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [ ] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
