### PR TITLE
fix(tests): isolate test schemas across concurrent engine variants in integration tests

### DIFF
--- a/tests/core/engine_adapter/integration/__init__.py
+++ b/tests/core/engine_adapter/integration/__init__.py
@@ -6,7 +6,7 @@ import sys
 import typing as t
 import time
 from contextlib import contextmanager
-
+import uuid
 import pandas as pd  # noqa: TID253
 import pytest
 from sqlglot import exp, parse_one
@@ -205,7 +205,7 @@ class TestContext:
         self.mark = mark
         self.gateway = gateway
         self._columns_to_types = columns_to_types
-        self.test_id = random_id(short=True)
+        self.test_id = f"{self.mark}_{uuid.uuid4().hex[:8]}" 
         self._context: t.Optional[Context] = None
         self.is_remote = is_remote
         self._schemas: t.List[
@@ -684,7 +684,7 @@ class TestContext:
                 private_sqlmesh_dir / "config.yml",
                 private_sqlmesh_dir / "config.yaml",
             ],
-            variables={"tmp_path": str(path or self.tmp_path)},
+            variables={"tmp_path": (path or self.tmp_path).as_posix()},
         )
         if config_mutator:
             config_mutator(self.gateway, config)

--- a/tests/core/engine_adapter/integration/conftest.py
+++ b/tests/core/engine_adapter/integration/conftest.py
@@ -35,7 +35,7 @@ def config(tmp_path: pathlib.Path) -> Config:
             pathlib.Path(os.path.join(os.path.dirname(__file__), "config.yaml")),
         ],
         personal_paths=[(SQLMESH_PATH / "config.yaml").expanduser()],
-        variables={"tmp_path": str(tmp_path)},
+        variables={"tmp_path": tmp_path.as_posix()},
     )
 
 
@@ -78,7 +78,9 @@ def create_engine_adapter(
         if engine_name == "duckdb":
             assert isinstance(connection_config, DuckDBConnectionConfig)
             for raw_path in [
-                v for v in (connection_config.catalogs or {}).values() if isinstance(v, str)
+                v
+                for v in (connection_config.catalogs or {}).values()
+                if isinstance(v, str) and v != ":memory:"
             ]:
                 pathlib.Path(raw_path).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Description & Context
Fixes schema and database collision between concurrent integration test runs (specifically `test_init_project[athena_hive]` and `test_init_project[athena_iceberg]`).

### Root Cause
`TestContext.__init__` previously generated `self.test_id` using `random_id(short=True)`. Because `self.mark` was not included in the ID and `random` was subject to worker seed duplication in parallel xdist runs (`gw0` and `gw1`), both Hive and Iceberg test variants generated the exact same database names (`test_schema_<test_id>` and `sqlmesh__test_schema_<test_id>`). This caused one worker to drop/modify schemas while the other was still validating tables.

### Changes
1. **Isolated Test IDs**: Updated `self.test_id` in `tests/core/engine_adapter/integration/__init__.py` to include `self.mark` and a unique UUID fragment: `f"{self.mark}_{uuid.uuid4().hex[:8]}"`.
   - `self.mark` ensures different table format variants (`athena_hive` vs `athena_iceberg`) never share a database name.
   - `uuid.uuid4().hex[:8]` guarantees worker entropy while keeping overall identifier lengths safely within the 64-character limit for engines with strict length limits (e.g. StarRocks, PostgreSQL).
2. **Cross-Platform Test Fixes**:
   - Converted `tmp_path` to `.as_posix()` in `tests/core/engine_adapter/integration/__init__.py` and `conftest.py` to prevent YAML scanner escape errors on Windows paths.
   - Skipped attempting to unlink `:memory:` catalog paths on Windows in `conftest.py`.

### Testing
- Ran linter: `uv run ruff check` (passed with all checks clean).
- Ran local integration test verification: `uv run pytest tests/core/engine_adapter/integration/test_integration.py -k "duckdb and test_init_project" -v` (passed).
