### PR TITLE
fix(snowflake): omit initialization warehouse from preview tables

### DIFF
--- a/sqlmesh/core/engine_adapter/snowflake.py
+++ b/sqlmesh/core/engine_adapter/snowflake.py
@@ -343,7 +343,13 @@ class SnowflakeEngineAdapter(
             # if we are creating a non-dynamic table; remove any properties that are only valid for dynamic tables
             # this is necessary because we create "normal" tables from the same managed model definition for dev previews and the "normal" tables dont support these parameters
             if "DYNAMIC" not in (table_kind or "").upper():
-                for prop in {"WAREHOUSE", "TARGET_LAG", "REFRESH_MODE", "INITIALIZE"}:
+                for prop in {
+                    "WAREHOUSE",
+                    "TARGET_LAG",
+                    "REFRESH_MODE",
+                    "INITIALIZE",
+                    "INITIALIZATION_WAREHOUSE",
+                }:
                     table_properties.pop(prop, None)
 
             table_type = self._pop_creatable_type_from_properties(table_properties)

--- a/tests/core/engine_adapter/test_snowflake.py
+++ b/tests/core/engine_adapter/test_snowflake.py
@@ -18,6 +18,8 @@ from sqlmesh.utils.errors import SQLMeshError
 from sqlmesh.utils import optional_import
 from tests.core.engine_adapter import to_sql_calls
 from sqlmesh.core.model.kind import ViewKind
+from sqlmesh.core.snapshot import DeployabilityIndex
+from sqlmesh.core.snapshot.evaluator import EngineManagedStrategy
 
 pytestmark = [pytest.mark.engine, pytest.mark.snowflake]
 
@@ -607,6 +609,85 @@ def test_ctas_skips_dynamic_table_properties(make_mocked_engine_adapter: t.Calla
     assert to_sql_calls(adapter) == [
         'CREATE TABLE IF NOT EXISTS "test_table" AS SELECT CAST("a" AS INT) AS "a", CAST("b" AS INT) AS "b" FROM (SELECT "a", "b" FROM "source_table") AS "_subquery"'
     ]
+
+
+@pytest.mark.parametrize(
+    "operation", ["create_annotated", "create_ctas", "insert", "create_managed"]
+)
+def test_managed_preview_dynamic_table_properties(
+    make_mocked_engine_adapter: t.Callable, mocker: MockerFixture, operation: str
+):
+    adapter = make_mocked_engine_adapter(SnowflakeEngineAdapter)
+    model = load_sql_based_model(
+        d.parse("""
+        MODEL (
+            name test_schema.test_model,
+            dialect snowflake,
+            kind MANAGED,
+            physical_properties (
+                warehouse = 'SMALL',
+                target_lag = '10 minutes',
+                refresh_mode = 'AUTO',
+                initialize = 'ON_CREATE',
+                initialization_warehouse = 'INITIAL_WH',
+                data_retention_time_in_days = 1,
+                max_data_extension_time_in_days = 2
+            )
+        );
+        SELECT a FROM source_table;
+    """)
+    )
+    properties = model.physical_properties
+    original_properties = {key: value.copy() for key, value in properties.items()}
+    strategy = EngineManagedStrategy(adapter)
+    mocker.patch.object(adapter, "columns", return_value={"A": exp.DataType.build("INT")})
+    if operation == "create_annotated":
+        model = model.copy(update={"columns_to_types_": {"A": exp.DataType.build("INT")}})
+    if operation == "insert":
+        strategy.insert(
+            "test_table",
+            model.render_query_or_raise(),
+            model,
+            True,
+            {},
+            deployability_index=DeployabilityIndex.none_deployable(),
+            snapshot=mocker.Mock(),
+            physical_properties=properties,
+        )
+    else:
+        strategy.create(
+            "test_table",
+            model,
+            operation == "create_managed",
+            {},
+            skip_grants=True,
+            is_snapshot_deployable=operation == "create_managed",
+            physical_properties=properties,
+        )
+    shared_properties = "DATA_RETENTION_TIME_IN_DAYS=1 MAX_DATA_EXTENSION_TIME_IN_DAYS=2"
+    query = 'SELECT "A" AS "A" FROM "SOURCE_TABLE" AS "SOURCE_TABLE"'
+    if operation == "create_annotated":
+        expected_sql = [
+            f'CREATE TABLE IF NOT EXISTS "test_table" ("A" INT) {shared_properties}',
+            f"{query} WHERE FALSE LIMIT 0",
+        ]
+    elif operation == "create_ctas":
+        expected_sql = [
+            f'CREATE TABLE IF NOT EXISTS "test_table" {shared_properties} AS {query} WHERE FALSE LIMIT 0'
+        ]
+    elif operation == "insert":
+        expected_sql = [
+            f'CREATE OR REPLACE TABLE "test_table" {shared_properties} AS SELECT CAST("A" AS INT) AS "A" FROM ({query}) AS "_subquery"'
+        ]
+    else:
+        expected_sql = [
+            'CREATE OR REPLACE DYNAMIC TABLE "test_table" '
+            "WAREHOUSE='SMALL' TARGET_LAG='10 minutes' REFRESH_MODE='AUTO' "
+            "INITIALIZE='ON_CREATE' INITIALIZATION_WAREHOUSE='INITIAL_WH' "
+            f"{shared_properties} AS {query}"
+        ]
+    assert to_sql_calls(adapter) == expected_sql
+    assert properties == original_properties
 
 
 def test_set_current_catalog(make_mocked_engine_adapter: t.Callable):


### PR DESCRIPTION
## Description

A Snowflake `MANAGED` model with `initialization_warehouse` passes that dynamic-table-only property into ordinary preview-table DDL. This happens during annotated preview creation, CTAS preview creation, and preview replacement.

Add `INITIALIZATION_WAREHOUSE` to Snowflake's existing non-dynamic-table property filter. Dynamic-table creation retains it; shared retention properties and the caller's property dictionary remain unchanged. No shared evaluator code, other adapters, or database lookups change.

Snowflake documents the property for [CREATE DYNAMIC TABLE](https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table), not [CREATE TABLE](https://docs.snowflake.com/en/sql-reference/sql/create-table).

## Test Plan

- [x] Three preview cases fail before the fix and pass after it, using the actual `EngineManagedStrategy` and a loaded managed model.
- [x] Exact-SQL assertions preserve production dynamic-table creation and shared retention properties; input properties remain unchanged in every case.
- [x] Snowflake adapter suite: 50 passed, one skipped.
- [x] `make style` passes.
- [x] `make fast-test`: 2,625 passed, four skipped; all 167 isolation tests pass.
- [ ] CI green. No live Snowflake execution was performed locally.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://github.com/SQLMesh/sqlmesh/blob/main/DCO)
