### PR TITLE
chore(md): noting pre-commit command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,11 @@ See [docs/development.md](docs/development.md) for full setup instructions. Key 
 python -m venv .venv
 source .venv/bin/activate
 make install-dev
-make style    # Run before submitting
+make style     # Run before submitting
 make fast-test # Quick test suite
 ```
+
+Optionally, `make install-pre-commit` installs git hooks so ruff and mypy run on `git commit`. Hooks do not replace `make style`: they run on staged files, while CI runs `make style` across the tree.
 
 ## Coding Standards
 


### PR DESCRIPTION
## Description

Noticing some contributors having their code fail on basic stuff like formatting or mypy linting checks. Noting in CONTRIBUTING.md that we have `make install-pre-commit` so those can be enforced on commits.

## Test Plan

N/A

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
