### PR TITLE
Feat: Add optional execution observations

### DIFF
--- a/docs/reference/execution_observations.md
+++ b/docs/reference/execution_observations.md
@@ -1,0 +1,132 @@
+# Execution observations
+
+Execution observations let Python integrations observe native SQLMesh work through
+an optional callback. They do not replace SQL generation, execution, retries,
+transactions, or Console progress reporting.
+
+## Register an observer
+
+Override `Console.get_execution_observer()` to return a callback accepting
+`phase`, `facts`, and `error`. Its default return value is `None`.
+Install the console before constructing the SQLMesh `Context`:
+
+```python
+from typing import Any, Literal, Mapping, Optional
+
+from sqlmesh.core.console import TerminalConsole, set_console
+from sqlmesh.core.context import Context
+from sqlmesh.core.execution_observation import Observer
+
+
+def observe(
+    phase: Literal["start", "finish"],
+    facts: Mapping[str, Any],
+    error: Optional[BaseException],
+) -> None:
+    if phase == "finish":
+        print(f"{facts['kind']}/{facts['action']}: error={error!r}")
+
+
+class ObservedConsole(TerminalConsole):
+    def get_execution_observer(self) -> Optional[Observer]:
+        return observe
+
+
+set_console(ObservedConsole())
+context = Context(paths=["path/to/project"])
+```
+
+Built-in plan-stage evaluation and scheduler dispatch resolve the getter at the
+outer observation boundary. Nested dispatch reuses the active registration.
+An ordinary `Exception` from the getter disables observation at that boundary;
+native work continues.
+
+For an explicitly bounded registration, use `observer_scope(observer)` from
+`sqlmesh.core.execution_observation`. Nested scopes restore the preceding
+registration on exit. `observer_scope(None)` explicitly disables observation
+inside the scope, including automatic Console registration.
+
+## Callback lifecycle
+
+`start` runs before the observed work, with `error=None`. Once the start callback
+returns, `finish` runs from `finally` after that work, with its original exception
+object or `None`. Both callbacks run synchronously on the invoking thread.
+
+SQLMesh passes the **same read-only mapping object** to start and finish for one
+invocation. Distinct invocations have distinct mappings. Consumers may retain the
+mapping until its matching finish callback to pair the calls by object identity;
+release it afterward. SQLMesh may add facts discovered during execution, so this
+mapping is a live view, not an immutable snapshot of the start facts.
+
+Nested workload calls produce nested observations. Callbacks for concurrent
+workers can interleave, and there is no global callback ordering. Observers must
+support concurrent calls and return promptly. SQLMesh does not allocate execution
+IDs, timestamps, durations, or parent IDs; consumers can maintain that information.
+
+Ordinary observer `Exception` failures are suppressed and do not replace the
+workload result or error. This guarantee does **not** cover observer-raised
+`BaseException` subclasses such as `KeyboardInterrupt` or `SystemExit`: a failure
+in start can prevent work and finish, and a failure in finish can replace a
+workload error. Blocking callbacks and process termination are also outside the
+guarantee. SQLMesh does not recursively log observer failures.
+
+While a callback is being delivered, observations triggered by that callback are
+suppressed, and internal metadata updates are ignored. This guard applies only
+during callback delivery: a normal model operation can still contain observed
+physical operations, audits, and queries.
+
+## Native facts and boundaries
+
+Every mapping contains `kind` and `action`. Other fields depend on the boundary
+and may be absent, particularly when work exits early or fails.
+
+| Kind | Action | Native facts |
+| --- | --- | --- |
+| `stage` | Native plan-stage name | `native_plan_id` |
+| `model` | `evaluate`, `audit_only` | `snapshot`, `interval`, `batch_index`, `execution_time`, `audit_only` |
+| `physical` | `create`, `materialize`, `schema_migration` | `snapshot`; `target` when known; `creating` for materialization; `existed` for schema migration when known |
+| `virtual` | `promote`, `demote` | `snapshot`; `target` when known; `source_table` for promotion when known |
+| `audit` | `audit` | `audit_name`; `audit_result` at finish if produced |
+| `query` | `execute` | `engine` dialect string |
+
+`Snapshot` and `AuditResult` values are borrowed native objects. Treat them and
+other nested values as read-only, and do not retain them beyond finish. The
+mapping's read-only wrapper does not freeze these objects. Normalize any values
+needed for later processing during the callback; facts are not a JSON event
+schema. SQLMesh does not interpret audit results as consumer statuses or inherit
+model facts into child mappings.
+
+Audit observations finish before later audits or WAP publication can fail. An
+audit query failure can produce a finish callback without an `AuditResult`.
+Physical materialization includes the surrounding transaction/session exit.
+An invocation can perform no work, multiple statements, or internal driver
+retries; observations are not an expected-work manifest or a retry inventory.
+
+The query boundary surrounds the base adapter's existing SQL logging and
+`_execute` call. It does not include a surrounding transaction's commit or later
+fetch/result consumption. Adapter paths that bypass this boundary, including
+BigQuery session queries and dataframe loads and ClickHouse dataframe inserts,
+do not necessarily produce query observations. These hooks therefore do not
+provide a complete warehouse activity history or a transaction-success guarantee.
+
+SQL logs retain their existing behavior, including VALUES redaction for
+non-query expressions. The callback does not receive SQL text, adapter objects,
+or warehouse query IDs. Starting the observation before SQL logging lets a
+consumer associate existing logs with the invocation.
+
+## Worker context
+
+When observation is active, the instrumented scheduler and snapshot DAG dispatch
+paths copy the admitting context at execution time. Each node runs in its own
+copy, including serial DAG execution. Consumer-owned `ContextVar` values can
+therefore carry parent identities into workers; successors inherit the admission
+context rather than the preceding worker's changes. Reusing a DAG executor
+captures a fresh context for each run.
+
+Context copies are shallow. Mutable objects stored in ContextVars can still be
+shared; consumers should use immutable values or replace values instead of
+mutating shared state. This behavior applies to the instrumented DAG paths, not
+to arbitrary consumer threads or every SQLMesh concurrency helper.
+
+With no observer registered, these call sites do not opt into context copying
+and retain their existing serial and worker execution behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - reference/cli.md
       - reference/notebook.md
       - reference/python.md
+      - reference/execution_observations.md
     - Configuration:
       - reference/configuration.md
       - reference/model_configuration.md

--- a/sqlmesh/core/console.py
+++ b/sqlmesh/core/console.py
@@ -407,6 +407,20 @@ class Console(
 
     INDIRECTLY_MODIFIED_DISPLAY_THRESHOLD = 10
 
+    def get_execution_observer(
+        self,
+    ) -> t.Optional[
+        t.Callable[
+            [t.Literal["start", "finish"], t.Mapping[str, t.Any], t.Optional[BaseException]], None
+        ]
+    ]:
+        """Optional start/finish hook receiving native facts and original errors.
+
+        May run concurrently. No IDs, clocks or product status are supplied.
+        Implementations must return promptly; ordinary hook errors are isolated.
+        """
+        return None
+
     @abc.abstractmethod
     def start_plan_evaluation(self, plan: EvaluatablePlan) -> None:
         """Indicates that a new evaluation has begun."""

--- a/sqlmesh/core/engine_adapter/base.py
+++ b/sqlmesh/core/engine_adapter/base.py
@@ -2624,12 +2624,17 @@ class EngineAdapter:
 
                 sql = self._attach_correlation_id(sql)
 
-                self._log_sql(
-                    sql,
-                    expression=e if isinstance(e, exp.Expr) else None,
-                    quote_identifiers=quote_identifiers,
-                )
-                self._execute(sql, track_rows_processed, **kwargs)
+                # The rendered statement and correlation comment are finalized
+                # here; observe the exact invocation, including driver errors.
+                from sqlmesh.core.execution_observation import action
+
+                with action("query", "execute", engine=self.dialect):
+                    self._log_sql(
+                        sql,
+                        expression=e if isinstance(e, exp.Expr) else None,
+                        quote_identifiers=quote_identifiers,
+                    )
+                    self._execute(sql, track_rows_processed, **kwargs)
 
     def _attach_correlation_id(self, sql: str) -> str:
         if self.ATTACH_CORRELATION_ID and self.correlation_id:

--- a/sqlmesh/core/execution_observation.py
+++ b/sqlmesh/core/execution_observation.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional native lifecycle hooks, independent of telemetry storage or policy.
+
+Call sites report start before native work and finish in finally, including the
+original error. Consumers must return promptly. Ordinary observer exceptions never
+replace workload results. The scope only routes hooks and late native metadata;
+execution IDs, timing, parent correlation and status mapping belong to consumers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import functools
+import typing as t
+from types import MappingProxyType
+
+Observer = t.Callable[
+    [t.Literal["start", "finish"], t.Mapping[str, t.Any], t.Optional[BaseException]], None
+]
+_dispatching: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "execution_observer_dispatch", default=False
+)
+_scoped: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "execution_observer_scoped", default=False
+)
+_observer: contextvars.ContextVar[t.Optional[Observer]] = contextvars.ContextVar(
+    "execution_observer", default=None
+)
+_metadata: contextvars.ContextVar[t.Optional[t.Dict[str, t.Any]]] = contextvars.ContextVar(
+    "execution_observation_metadata", default=None
+)
+
+
+def update_execution(**metadata: t.Any) -> None:
+    """Supply native facts discovered inside the current hook boundary."""
+    current = _metadata.get()
+    if current is not None and not _dispatching.get():
+        current.update(metadata)
+
+
+@contextlib.contextmanager
+def observer_scope(observer: t.Optional[Observer]) -> t.Iterator[None]:
+    token = _observer.set(observer)
+    scope_token = _scoped.set(True)
+    metadata_token = _metadata.set(None)
+    try:
+        yield
+    finally:
+        _metadata.reset(metadata_token)
+        _scoped.reset(scope_token)
+        _observer.reset(token)
+
+
+def _notify(
+    observer: Observer,
+    phase: t.Literal["start", "finish"],
+    metadata: t.Mapping[str, t.Any],
+    error: t.Optional[BaseException] = None,
+) -> None:
+    token = _dispatching.set(True)
+    try:
+        observer(phase, metadata, error)
+    except Exception:
+        # Hooks are observational: do not alter execution or recursively log a
+        # telemetry failure. Consumers own their capture-loss reporting.
+        pass
+    finally:
+        _dispatching.reset(token)
+
+
+@contextlib.contextmanager
+def action(kind: str, name: str, **metadata: t.Any) -> t.Iterator[t.Optional[t.Dict[str, t.Any]]]:
+    observer = _observer.get()
+    if observer is None or _dispatching.get():
+        yield None
+        return
+    data = {**metadata, "kind": kind, "action": name}
+    view = MappingProxyType(data)
+    token = _metadata.set(data)
+    try:
+        _notify(observer, "start", view)
+        error: t.Optional[BaseException] = None
+        try:
+            yield data
+        except BaseException as ex:
+            error = ex
+            raise
+        finally:
+            _notify(observer, "finish", view, error)
+    finally:
+        _metadata.reset(token)
+
+
+def observe_snapshot(kind: str, name: str) -> t.Callable:
+    """Hook evaluator methods whose first argument after self is snapshot.
+
+    Verified callers pass Snapshot as that argument (positional or keyword).
+    Pass the native object unchanged; no reflection, identity formatting, skip
+    classification or snapshot interpretation is performed by this hook.
+    """
+
+    def decorate(function: t.Callable) -> t.Callable:
+        @functools.wraps(function)
+        def wrapped(self: t.Any, snapshot: t.Any, *args: t.Any, **kwargs: t.Any) -> t.Any:
+            with action(kind, name, snapshot=snapshot):
+                return function(self, snapshot, *args, **kwargs)
+
+        return wrapped
+
+    return decorate
+
+
+def execution_context_factory() -> t.Optional[t.Callable[[], contextvars.Context]]:
+    """Opt in to worker context propagation only during active observation."""
+    return (
+        contextvars.copy_context if _observer.get() is not None and not _dispatching.get() else None
+    )
+
+
+@contextlib.contextmanager
+def console_observer_scope(console: t.Any) -> t.Iterator[None]:
+    """Resolve once at the outer boundary; an explicit None scope disables hooks."""
+    if _scoped.get():
+        yield
+        return
+    try:
+        observer = console.get_execution_observer()
+    except Exception:
+        observer = None
+    with observer_scope(observer):
+        yield

--- a/sqlmesh/core/plan/evaluator.py
+++ b/sqlmesh/core/plan/evaluator.py
@@ -18,6 +18,7 @@ import abc
 import logging
 import typing as t
 from sqlmesh.core import analytics
+from sqlmesh.core.execution_observation import action, console_observer_scope
 from sqlmesh.core import constants as c
 from sqlmesh.core.console import Console, get_console
 from sqlmesh.core.environment import EnvironmentNamingInfo, execute_environment_statements
@@ -102,7 +103,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
 
         try:
             plan_stages = stages.build_plan_stages(plan, self.state_sync, self.default_catalog)
-            self._evaluate_stages(plan_stages, plan)
+            with console_observer_scope(self.console):
+                self._evaluate_stages(plan_stages, plan)
         except Exception as e:
             analytics.collector.on_plan_apply_end(plan_id=plan.plan_id, error=e)
             raise
@@ -122,7 +124,8 @@ class BuiltInPlanEvaluator(PlanEvaluator):
                 raise SQLMeshError(f"Unexpected plan stage: {stage_name}")
             logger.info("Evaluating plan stage %s", stage_name)
             handler = getattr(self, handler_name)
-            handler(stage, plan)
+            with action("stage", stage_name, native_plan_id=plan.plan_id):
+                handler(stage, plan)
 
     def visit_before_all_stage(self, stage: stages.BeforeAllStage, plan: EvaluatablePlan) -> None:
         execute_environment_statements(

--- a/sqlmesh/core/scheduler.py
+++ b/sqlmesh/core/scheduler.py
@@ -8,6 +8,11 @@ from datetime import datetime
 from sqlglot import exp
 from sqlmesh.core import constants as c
 from sqlmesh.core.console import Console, get_console
+from sqlmesh.core.execution_observation import (
+    action,
+    console_observer_scope,
+    execution_context_factory,
+)
 from sqlmesh.core.environment import EnvironmentNamingInfo, execute_environment_statements
 from sqlmesh.core.macros import RuntimeStage
 from sqlmesh.core.model.definition import AuditResult
@@ -518,6 +523,21 @@ class Scheduler:
         )
 
         def run_node(node: SchedulingUnit) -> None:
+            if isinstance(node, EvaluateNode):
+                with action(
+                    "model",
+                    "audit_only" if audit_only else "evaluate",
+                    snapshot=self.snapshots_by_name[node.snapshot_name],
+                    interval=node.interval,
+                    batch_index=node.batch_index,
+                    execution_time=execution_time,
+                    audit_only=audit_only,
+                ):
+                    execute_node(node)
+            else:
+                execute_node(node)
+
+        def execute_node(node: SchedulingUnit) -> None:
             if circuit_breaker and circuit_breaker():
                 raise CircuitBreakerError()
             if isinstance(node, DummyNode):
@@ -596,12 +616,13 @@ class Scheduler:
                 )
 
         try:
-            with self.snapshot_evaluator.concurrent_context():
+            with console_observer_scope(self.console), self.snapshot_evaluator.concurrent_context():
                 errors, skipped_intervals = concurrent_apply_to_dag(
                     dag,
                     run_node,
                     self.max_workers,
                     raise_on_error=False,
+                    context_factory=execution_context_factory(),
                 )
                 self.console.stop_evaluation_progress(success=not errors)
 

--- a/sqlmesh/core/snapshot/evaluator.py
+++ b/sqlmesh/core/snapshot/evaluator.py
@@ -29,6 +29,12 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import reduce
+from sqlmesh.core.execution_observation import (
+    action,
+    observe_snapshot,
+    update_execution,
+    execution_context_factory,
+)
 
 from sqlglot import exp, select
 from sqlglot.executor import execute
@@ -327,6 +333,7 @@ class SnapshotEvaluator:
                     on_complete=on_complete,
                 ),
                 self.ddl_concurrent_tasks,
+                context_factory=execution_context_factory(),
             )
 
     def demote(
@@ -355,6 +362,7 @@ class SnapshotEvaluator:
                     table_mapping=table_mapping,
                 ),
                 self.ddl_concurrent_tasks,
+                context_factory=execution_context_factory(),
             )
 
     def create(
@@ -465,6 +473,7 @@ class SnapshotEvaluator:
                     on_complete=on_complete,
                 ),
                 self.ddl_concurrent_tasks,
+                context_factory=execution_context_factory(),
                 raise_on_error=False,
             )
             if errors:
@@ -512,6 +521,7 @@ class SnapshotEvaluator:
                     deployability_index,
                 ),
                 self.ddl_concurrent_tasks,
+                context_factory=execution_context_factory(),
             )
 
     def cleanup(
@@ -556,6 +566,7 @@ class SnapshotEvaluator:
                     on_complete,
                 ),
                 self.ddl_concurrent_tasks,
+                context_factory=execution_context_factory(),
                 reverse_order=True,
                 raise_on_error=False,
             )
@@ -634,8 +645,11 @@ class SnapshotEvaluator:
                 # so that we can fall back to the audit's setting, which we override to blocking: False
                 audit = audit.model_copy(update={"blocking": False})
 
-            results.append(
-                self._audit(
+            # Observe before calling _audit: query exceptions need a terminal
+            # event even when no AuditResult exists. Preserve completed audits
+            # before later aggregate handling or WAP publication can fail.
+            with action("audit", "audit", audit_name=audit.name) as observation:
+                audit_result = self._audit(
                     audit=audit,
                     audit_args=audit_args,
                     snapshot=snapshot,
@@ -646,7 +660,9 @@ class SnapshotEvaluator:
                     deployability_index=deployability_index,
                     **kwargs,
                 )
-            )
+                if observation is not None:
+                    observation["audit_result"] = audit_result
+            results.append(audit_result)
 
         if wap_id is not None:
             logger.info(
@@ -776,6 +792,16 @@ class SnapshotEvaluator:
         )
 
         with (
+            # The first batch may create via CTAS instead of create_snapshot.
+            # Observe the materialization, including its transaction exit, so
+            # lazy creation is not missing from physical-layer history.
+            action(
+                "physical",
+                "materialize",
+                target=target_table_name,
+                creating=not target_table_exists,
+                snapshot=snapshot,
+            ),
             adapter.transaction(),
             adapter.session(snapshot.model.render_session_properties(**render_statements_kwargs)),
         ):
@@ -864,6 +890,7 @@ class SnapshotEvaluator:
 
         return wap_id
 
+    @observe_snapshot("physical", "create")
     def create_snapshot(
         self,
         snapshot: Snapshot,
@@ -887,6 +914,9 @@ class SnapshotEvaluator:
             return
 
         logger.info("Creating a physical table for snapshot %s", snapshot.snapshot_id)
+        update_execution(
+            target=snapshot.table_name(is_deployable=deployability_index.is_deployable(snapshot)),
+        )
 
         adapter = self.get_adapter(snapshot.model.gateway)
         create_render_kwargs: t.Dict[str, t.Any] = dict(
@@ -1121,6 +1151,7 @@ class SnapshotEvaluator:
             adapter.drop_table(target_table_name)
             raise
 
+    @observe_snapshot("physical", "schema_migration")
     def _migrate_snapshot(
         self,
         snapshot: Snapshot,
@@ -1142,6 +1173,7 @@ class SnapshotEvaluator:
             deployability_index=deployability_index,
         )
         target_table_name = snapshot.table_name()
+        update_execution(target=target_table_name, existed=target_data_object is not None)
 
         evaluation_strategy = _evaluation_strategy(snapshot, adapter)
         evaluation_strategy.run_pre_statements(
@@ -1250,6 +1282,7 @@ class SnapshotEvaluator:
             if snapshot.is_materialized:
                 adapter.drop_table(tmp_table_name)
 
+    @observe_snapshot("virtual", "promote")
     def _promote_snapshot(
         self,
         snapshot: Snapshot,
@@ -1274,6 +1307,7 @@ class SnapshotEvaluator:
         view_name = snapshot.qualified_view_name.for_environment(
             environment_naming_info, dialect=adapter.dialect
         )
+        update_execution(target=view_name, source_table=table_name)
         render_kwargs: t.Dict[str, t.Any] = dict(
             start=start,
             end=end,
@@ -1305,6 +1339,7 @@ class SnapshotEvaluator:
         if on_complete is not None:
             on_complete(snapshot)
 
+    @observe_snapshot("virtual", "demote")
     def _demote_snapshot(
         self,
         snapshot: Snapshot,
@@ -1324,6 +1359,7 @@ class SnapshotEvaluator:
         view_name = snapshot.qualified_view_name.for_environment(
             environment_naming_info, dialect=adapter.dialect
         )
+        update_execution(target=view_name)
         with (
             adapter.transaction(),
             adapter.session(

--- a/sqlmesh/utils/concurrency.py
+++ b/sqlmesh/utils/concurrency.py
@@ -1,6 +1,7 @@
 import typing as t
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from threading import Lock
+from contextvars import Context
 
 from sqlmesh.core.snapshot import SnapshotId, SnapshotInfoLike
 from sqlmesh.utils.dag import DAG
@@ -30,6 +31,9 @@ class ConcurrentDAGExecutor(t.Generic[H]):
         raise_on_error: If set to True raises an exception on a first encountered error,
             otherwises returns a tuple which contains a list of failed nodes and a list of
             skipped nodes.
+        context_factory: Optional factory called at each run admission. Each node runs
+            in a separate copy of that context, including serial execution. By default
+            no context is captured or copied.
     """
 
     def __init__(
@@ -38,11 +42,14 @@ class ConcurrentDAGExecutor(t.Generic[H]):
         fn: t.Callable[[H], None],
         tasks_num: int,
         raise_on_error: bool,
+        context_factory: t.Optional[t.Callable[[], Context]] = None,
     ):
         self.dag = dag
         self.fn = fn
         self.tasks_num = tasks_num
         self.raise_on_error = raise_on_error
+        self.context_factory = context_factory
+        self._context: t.Optional[Context] = None
 
         self._init_state()
 
@@ -55,14 +62,18 @@ class ConcurrentDAGExecutor(t.Generic[H]):
         Returns:
             A pair which contains a list of node errors and a list of skipped nodes.
         """
+        self._context = self.context_factory() if self.context_factory else None
         if self._finished_future.done():
             self._init_state()
 
-        with ThreadPoolExecutor(max_workers=self.tasks_num) as pool:
-            with self._unprocessed_nodes_lock:
-                self._submit_next_nodes(pool)
-            self._finished_future.result()
-        return self._node_errors, self._skipped_nodes
+        try:
+            with ThreadPoolExecutor(max_workers=self.tasks_num) as pool:
+                with self._unprocessed_nodes_lock:
+                    self._submit_next_nodes(pool)
+                self._finished_future.result()
+            return self._node_errors, self._skipped_nodes
+        finally:
+            self._context = None
 
     def _process_node(self, node: H, executor: Executor) -> None:
         try:
@@ -98,7 +109,12 @@ class ConcurrentDAGExecutor(t.Generic[H]):
 
         for submitted_node in submitted_nodes:
             self._unprocessed_nodes.pop(submitted_node)
-            executor.submit(self._process_node, submitted_node, executor)
+            if self._context is None:
+                executor.submit(self._process_node, submitted_node, executor)
+            else:
+                executor.submit(
+                    self._context.copy().run, self._process_node, submitted_node, executor
+                )
 
     def _skip_next_nodes(self, parent: H) -> None:
         if not self._unprocessed_nodes_num:
@@ -139,6 +155,7 @@ def concurrent_apply_to_snapshots(
     tasks_num: int,
     reverse_order: bool = False,
     raise_on_error: bool = True,
+    context_factory: t.Optional[t.Callable[[], Context]] = None,
 ) -> t.Tuple[t.List[NodeExecutionFailedError[SnapshotId]], t.List[SnapshotId]]:
     """Applies a function to the given collection of snapshots concurrently while
     preserving the topological order between snapshots.
@@ -151,6 +168,9 @@ def concurrent_apply_to_snapshots(
         raise_on_error: If set to True raises an exception on a first encountered error,
             otherwises returns a tuple which contains a list of failed nodes and a list of
             skipped nodes.
+        context_factory: Optional factory called at each run admission. Each node runs
+            in a separate copy of that context, including serial execution. By default
+            no context is captured or copied.
 
     Raises:
         NodeExecutionFailedError if `raise_on_error` is set to True and execution fails for any snapshot.
@@ -172,6 +192,7 @@ def concurrent_apply_to_snapshots(
         lambda s_id: fn(snapshots_by_id[s_id]),
         tasks_num,
         raise_on_error=raise_on_error,
+        context_factory=context_factory,
     )
 
 
@@ -180,6 +201,7 @@ def concurrent_apply_to_dag(
     fn: t.Callable[[H], None],
     tasks_num: int,
     raise_on_error: bool = True,
+    context_factory: t.Optional[t.Callable[[], Context]] = None,
 ) -> t.Tuple[t.List[NodeExecutionFailedError[H]], t.List[H]]:
     """Applies a function to the given DAG concurrently while preserving the topological
     order between snapshots.
@@ -191,6 +213,9 @@ def concurrent_apply_to_dag(
         raise_on_error: If set to True raises an exception on a first encountered error,
             otherwises returns a tuple which contains a list of failed nodes and a list of
             skipped nodes.
+        context_factory: Optional factory called at each run admission. Each node runs
+            in a separate copy of that context, including serial execution. By default
+            no context is captured or copied.
 
     Raises:
         NodeExecutionFailedError if `raise_on_error` is set to True and execution fails for any snapshot.
@@ -202,13 +227,14 @@ def concurrent_apply_to_dag(
         raise ConfigError(f"Invalid number of concurrent tasks {tasks_num}")
 
     if tasks_num == 1:
-        return sequential_apply_to_dag(dag, fn, raise_on_error)
+        return sequential_apply_to_dag(dag, fn, raise_on_error, context_factory)
 
     return ConcurrentDAGExecutor(
         dag,
         fn,
         tasks_num,
         raise_on_error,
+        context_factory,
     ).run()
 
 
@@ -216,7 +242,9 @@ def sequential_apply_to_dag(
     dag: DAG[H],
     fn: t.Callable[[H], None],
     raise_on_error: bool = True,
+    context_factory: t.Optional[t.Callable[[], Context]] = None,
 ) -> t.Tuple[t.List[NodeExecutionFailedError[H]], t.List[H]]:
+    context = context_factory() if context_factory else None
     dependencies = dag.graph
 
     node_errors: t.List[NodeExecutionFailedError[H]] = []
@@ -231,7 +259,10 @@ def sequential_apply_to_dag(
             continue
 
         try:
-            fn(node)
+            if context is None:
+                fn(node)
+            else:
+                context.copy().run(fn, node)
         except Exception as ex:
             error = NodeExecutionFailedError(node)
             error.__cause__ = ex

--- a/tests/core/test_execution_observation.py
+++ b/tests/core/test_execution_observation.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from dataclasses import dataclass, field
+from contextvars import ContextVar
+
+import pytest
+
+from sqlmesh.core.execution_observation import (
+    action,
+    observer_scope,
+    update_execution,
+    execution_context_factory,
+)
+
+
+@dataclass
+class Observer:
+    events: list = field(default_factory=list)
+
+    def __call__(self, phase, facts, error):
+        self.events.append((phase, dict(facts), error))
+
+
+def test_native_facts_have_no_telemetry_policy():
+    observer = Observer()
+    error = ValueError("view failed")
+    with observer_scope(observer), pytest.raises(ValueError) as raised:
+        with action("virtual", "promote", target="view"):
+            update_execution(source_table="table")
+            raise error
+    assert raised.value is error
+    assert observer.events == [
+        ("start", {"kind": "virtual", "action": "promote", "target": "view"}, None),
+        (
+            "finish",
+            {"kind": "virtual", "action": "promote", "target": "view", "source_table": "table"},
+            error,
+        ),
+    ]
+
+
+@pytest.mark.parametrize("phase", ["start", "finish"])
+@pytest.mark.parametrize("failure", [None, ValueError("native failure"), KeyboardInterrupt()])
+def test_observer_errors_cannot_change_workload_outcome(phase, failure):
+    calls = []
+
+    def observer(event, facts, error):
+        calls.append(event)
+        if event == phase:
+            raise RuntimeError("observer failure")
+
+    def workload():
+        with observer_scope(observer), action("query", "execute"):
+            if failure is not None:
+                raise failure
+            return 42
+
+    if failure is None:
+        assert workload() == 42
+    else:
+        with pytest.raises(type(failure)) as raised:
+            workload()
+        assert raised.value is failure
+    assert calls == ["start", "finish"]
+
+
+def test_disabled_observer_does_not_create_metadata():
+    from sqlmesh.core.console import TerminalConsole
+
+    assert TerminalConsole().get_execution_observer() is None
+    with action("query", "execute") as metadata:
+        assert metadata is None
+
+
+def test_real_adapter_preserves_sql_and_errors(duck_conn, caplog):
+    from sqlmesh.core.engine_adapter import DuckDBEngineAdapter
+
+    adapter = DuckDBEngineAdapter(lambda: duck_conn)
+    observer = Observer()
+    sql = "SELECT\n  1 AS observed_value"
+    with caplog.at_level(logging.DEBUG), observer_scope(observer):
+        adapter.execute(sql)
+        with pytest.raises(Exception):
+            adapter.execute("SELECT * FROM missing_observed_table")
+    queries = [event for event in observer.events if event[0] == "finish"]
+    assert len(queries) == 2
+    assert queries[0][2] is None
+    assert queries[1][2] is not None
+    assert all(
+        event[1] == {"kind": "query", "action": "execute", "engine": "duckdb"} for event in queries
+    )
+    assert f"Executing SQL: {sql}" in [record.getMessage() for record in caplog.records]
+    assert "Executing SQL: SELECT * FROM missing_observed_table" in [
+        record.getMessage() for record in caplog.records
+    ]
+
+
+def test_native_dag_copies_consumer_context_not_predecessor_context():
+    from sqlmesh.utils.concurrency import ConcurrentDAGExecutor
+    from sqlmesh.utils.dag import DAG
+
+    consumer_context = ContextVar("consumer_context", default=None)
+    observer = Observer()
+    dag = DAG()
+    dag.add("second", {"first"})
+
+    def execute(name):
+        assert consumer_context.get() == "stage"
+        consumer_context.set(name)
+        with action("physical", "create", target=name):
+            pass
+
+    with observer_scope(observer):
+        token = consumer_context.set("stage")
+        try:
+            errors, skipped = ConcurrentDAGExecutor(
+                dag, execute, 2, False, execution_context_factory()
+            ).run()
+        finally:
+            consumer_context.reset(token)
+    assert not errors and not skipped
+    assert len(observer.events) == 4
+
+
+def test_concurrent_model_hooks_keep_batch_context_and_original_failures():
+    """Real DAG workers retain independent batch scopes even when one fails."""
+    from threading import Barrier, Lock, get_ident
+
+    from sqlmesh.utils.concurrency import ConcurrentDAGExecutor
+    from sqlmesh.utils.dag import DAG
+
+    consumer_context = ContextVar("batch_context", default="plan")
+    barrier = Barrier(2)
+    lock = Lock()
+    events = []
+    failure = RuntimeError("model evaluation failed")
+    dag = DAG()
+    dag.add(0)
+    dag.add(1)
+
+    def observer(phase, facts, error):
+        with lock:
+            events.append((phase, dict(facts), error, get_ident(), consumer_context.get()))
+
+    def execute(batch):
+        assert consumer_context.get() == "plan"
+        token = consumer_context.set(batch)
+        try:
+            with action("model", "evaluate", batch_index=batch, interval=(batch, batch + 1)):
+                barrier.wait(timeout=5)
+                if batch == 1:
+                    raise failure
+        finally:
+            consumer_context.reset(token)
+
+    with observer_scope(observer):
+        errors, skipped = ConcurrentDAGExecutor(
+            dag, execute, 2, False, execution_context_factory()
+        ).run()
+    assert len(errors) == 1 and errors[0].__cause__ is failure
+    assert not skipped
+    assert len({event[3] for event in events}) == 2
+    for batch in (0, 1):
+        batch_events = [event for event in events if event[1]["batch_index"] == batch]
+        assert [event[0] for event in batch_events] == ["start", "finish"]
+        assert all(event[4] == batch for event in batch_events)
+        assert batch_events[-1][2] is (failure if batch == 1 else None)
+    assert consumer_context.get() == "plan"
+
+
+def test_read_only_identity_and_callback_reentry():
+    events = []
+    native = object()
+
+    def observer(phase, facts, error):
+        events.append((phase, facts, error))
+        with pytest.raises(TypeError):
+            facts["kind"] = "corrupt"
+        update_execution(corrupt=True)
+        with action("query", "observer-query"):
+            update_execution(corrupt=True)
+
+    with observer_scope(observer), action("model", "evaluate", snapshot=native):
+        with action("query", "execute"):
+            update_execution(late=True)
+        update_execution(target="late table")
+    assert [event[0] for event in events] == ["start", "start", "finish", "finish"]
+    assert events[0][1] is events[-1][1]
+    assert events[1][1] is events[2][1]
+    assert events[-1][1]["snapshot"] is native
+    assert events[-1][1]["target"] == "late table"
+    assert "late" not in events[-1][1]
+    assert all("corrupt" not in event[1] for event in events)
+
+
+def test_explicit_disabled_scope_isolates_parent_metadata():
+    observer = Observer()
+    with observer_scope(observer), action("model", "evaluate"):
+        with observer_scope(None), action("query", "execute"):
+            update_execution(corrupt=True)
+        update_execution(target="parent")
+    assert len(observer.events) == 2
+    assert observer.events[-1][1] == {"kind": "model", "action": "evaluate", "target": "parent"}
+
+
+@pytest.mark.parametrize("tasks_num", [1, 2])
+def test_context_admission_and_sibling_isolation(tasks_num):
+    from contextvars import copy_context
+    from sqlmesh.utils.concurrency import ConcurrentDAGExecutor, concurrent_apply_to_dag
+    from sqlmesh.utils.dag import DAG
+
+    consumer = ContextVar("admission", default="construction")
+    dag = DAG()
+    dag.add("second", {"first"})
+    seen = []
+
+    def execute(node):
+        seen.append(consumer.get())
+        consumer.set(node)
+
+    executor = ConcurrentDAGExecutor(dag, execute, tasks_num, False, copy_context)
+    token = consumer.set("first admission")
+    try:
+        executor.run()
+        consumer.set("second admission")
+        executor.run()
+        concurrent_apply_to_dag(dag, execute, tasks_num, context_factory=copy_context)
+        assert consumer.get() == "second admission"
+    finally:
+        consumer.reset(token)
+    assert seen == ["first admission"] * 2 + ["second admission"] * 4
+
+
+def test_console_scope_getter_failure_and_nested_reuse():
+    from sqlmesh.core.execution_observation import console_observer_scope
+    from unittest.mock import Mock
+
+    console = Mock()
+    console.get_execution_observer.side_effect = ValueError("getter failed")
+    with console_observer_scope(console), action("query", "execute") as facts:
+        assert facts is None
+    observer = Observer()
+    console.reset_mock(side_effect=True)
+    console.get_execution_observer.return_value = observer
+    with console_observer_scope(console):
+        with console_observer_scope(console), action("model", "evaluate"):
+            pass
+    console.get_execution_observer.assert_called_once_with()
+    assert len(observer.events) == 2
+    console.reset_mock()
+    with observer_scope(None), console_observer_scope(console):
+        with action("query", "execute") as facts:
+            assert facts is None
+    console.get_execution_observer.assert_not_called()
+
+
+def test_unobserved_context_factory_is_disabled():
+    assert execution_context_factory() is None
+    with observer_scope(None):
+        assert execution_context_factory() is None
+
+
+@pytest.mark.parametrize("phase", ["start", "finish"])
+def test_callback_base_exception_propagates_and_scope_is_restored(phase):
+    interrupt = KeyboardInterrupt()
+    events = []
+
+    def observer(event, facts, error):
+        events.append(event)
+        if event == phase:
+            raise interrupt
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        with observer_scope(observer), action("query", "execute"):
+            pass
+    assert raised.value is interrupt
+    assert events == (["start"] if phase == "start" else ["start", "finish"])
+    with action("query", "execute") as facts:
+        assert facts is None
+    observed = Observer()
+    with observer_scope(observed), action("model", "evaluate"):
+        update_execution(target="clean")
+    assert len(observed.events) == 2
+    assert observed.events[-1][1]["target"] == "clean"
+
+
+def test_disabled_and_observed_adapter_sql_and_side_effects_match(duck_conn, mocker):
+    from sqlmesh.core.engine_adapter import DuckDBEngineAdapter
+
+    adapter = DuckDBEngineAdapter(lambda: duck_conn)
+    execute = mocker.spy(adapter, "_execute")
+    sql_log = mocker.spy(adapter, "_log_sql")
+    sql = "CREATE OR REPLACE TABLE observed_effect AS SELECT 42 AS value"
+    calls = []
+    for observer in (None, Observer()):
+        execute.reset_mock()
+        sql_log.reset_mock()
+        with observer_scope(observer):
+            adapter.execute(sql)
+        calls.append((execute.call_args_list, sql_log.call_args_list))
+        assert duck_conn.execute("SELECT value FROM observed_effect").fetchall() == [(42,)]
+    assert calls[0] == calls[1]
+    assert len(calls[0][0]) == 1
+
+
+def test_default_dag_does_not_capture_context(mocker):
+    from sqlmesh.utils.concurrency import ConcurrentDAGExecutor, concurrent_apply_to_dag
+    from sqlmesh.utils.dag import DAG
+
+    copy = mocker.patch("contextvars.copy_context", side_effect=AssertionError("unexpected copy"))
+    dag = DAG()
+    dag.add("node")
+    for workers in (1, 2):
+        concurrent_apply_to_dag(dag, lambda _: None, workers)
+        executor = ConcurrentDAGExecutor(dag, lambda _: None, workers, False)
+        executor.run()
+        assert executor._context is None
+    copy.assert_not_called()
+
+
+@pytest.mark.parametrize("workers", [1, 2])
+@pytest.mark.parametrize("registration", ["console", "explicit", "disabled", "broken"])
+def test_plan_and_scheduler_registration(mocker, make_snapshot, workers, registration):
+    from contextlib import nullcontext
+    from sqlglot import parse_one
+    from sqlmesh.core.console import TerminalConsole
+    from sqlmesh.core.environment import EnvironmentNamingInfo
+    from sqlmesh.core.model import SqlModel, FullKind
+    from sqlmesh.core.plan.evaluator import BuiltInPlanEvaluator
+    from sqlmesh.core.plan import stages
+    from sqlmesh.core.scheduler import Scheduler
+    from sqlmesh.core.snapshot import DeployabilityIndex, SnapshotChangeCategory
+    from sqlmesh.utils.date import to_timestamp
+
+    snapshot = make_snapshot(
+        SqlModel(name="test.model", kind=FullKind(), query=parse_one("SELECT 1 AS a"))
+    )
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    console = TerminalConsole()
+    observer = Observer()
+    getter = mocker.patch.object(console, "get_execution_observer", return_value=observer)
+    if registration == "broken":
+        getter.side_effect = RuntimeError("getter failure")
+    native = mocker.MagicMock()
+    native.get_snapshots_to_create.return_value = []
+    native.set_correlation_id.return_value = native
+    scheduler = Scheduler(
+        [snapshot], native, mocker.MagicMock(), None, max_workers=workers, console=console
+    )
+    workload = []
+    consumer = ContextVar("plan_consumer", default=None)
+
+    def evaluate(*args, **kwargs):
+        if registration in ("console", "explicit"):
+            assert consumer.get() == "stage"
+        with action("query", "execute"):
+            workload.append(True)
+        return []
+
+    mocker.patch.object(scheduler, "evaluate", side_effect=evaluate)
+    evaluator = BuiltInPlanEvaluator(
+        mocker.MagicMock(), native, mocker.Mock(), None, console=console
+    )
+    stage = stages.BeforeAllStage(statements=[], all_snapshots=[])
+    mocker.patch("sqlmesh.core.plan.evaluator.stages.build_plan_stages", return_value=[stage])
+    mocker.patch("sqlmesh.core.plan.evaluator.analytics.collector")
+
+    def run_scheduler(*args):
+        token = consumer.set("stage")
+        try:
+            errors, skipped = scheduler.run_merged_intervals(
+                merged_intervals={
+                    snapshot: [(to_timestamp("2024-01-01"), to_timestamp("2024-01-02"))]
+                },
+                deployability_index=DeployabilityIndex.all_deployable(),
+                environment_naming_info=EnvironmentNamingInfo(),
+            )
+            assert not errors and not skipped
+        finally:
+            consumer.reset(token)
+
+    mocker.patch.object(evaluator, "visit_before_all_stage", side_effect=run_scheduler)
+    scope = (
+        observer_scope(observer if registration == "explicit" else None)
+        if registration in ("explicit", "disabled")
+        else nullcontext()
+    )
+    with scope:
+        evaluator.evaluate(mocker.Mock(plan_id="observed-plan"))
+    assert workload == [True]
+    assert getter.call_count == (1 if registration in ("console", "broken") else 0)
+    if registration in ("console", "explicit"):
+        assert [(phase, facts["kind"]) for phase, facts, _ in observer.events] == [
+            ("start", "stage"),
+            ("start", "model"),
+            ("start", "query"),
+            ("finish", "query"),
+            ("finish", "model"),
+            ("finish", "stage"),
+        ]
+    else:
+        assert observer.events == []

--- a/tests/core/test_snapshot_evaluator.py
+++ b/tests/core/test_snapshot_evaluator.py
@@ -28,6 +28,7 @@ from sqlmesh.core.engine_adapter.shared import (
 from sqlmesh.core.environment import EnvironmentNamingInfo
 from sqlmesh.core.macros import RuntimeStage, macro, MacroEvaluator, MacroFunc
 from sqlmesh.core.model import (
+    AuditResult,
     Model,
     FullKind,
     IncrementalByTimeRangeKind,
@@ -3283,6 +3284,26 @@ def test_standalone_audit(mocker: MockerFixture, adapter_mock, make_snapshot):
     adapter_mock.session.assert_not_called()
 
 
+def _audit_observed(
+    evaluator: SnapshotEvaluator,
+    snapshot: Snapshot,
+    *,
+    observe_result: t.Callable[[AuditResult], None],
+    **kwargs: t.Any,
+) -> t.List[AuditResult]:
+    """Exercise the generic hook at the real per-audit evaluator boundary."""
+    from sqlmesh.core.execution_observation import observer_scope
+
+    def observer(
+        phase: str, facts: t.Mapping[str, t.Any], error: t.Optional[BaseException]
+    ) -> None:
+        if phase == "finish" and facts["kind"] == "audit" and "audit_result" in facts:
+            observe_result(facts["audit_result"])
+
+    with observer_scope(observer):
+        return evaluator.audit(snapshot, **kwargs)
+
+
 def test_audit_wap(adapter_mock: Mock, make_snapshot: t.Callable[..., Snapshot]) -> None:
     evaluator = SnapshotEvaluator(adapter_mock)
 
@@ -3308,8 +3329,15 @@ def test_audit_wap(adapter_mock: Mock, make_snapshot: t.Callable[..., Snapshot])
     expected_table_name = f"spark_catalog.test_schema.test_table.branch_wap_{wap_id}"
     adapter_mock.wap_table_name.return_value = expected_table_name
     adapter_mock.fetchone.return_value = (0,)
+    observed_results: t.List[AuditResult] = []
 
-    evaluator.audit(snapshot, snapshots={}, wap_id=wap_id)
+    _audit_observed(
+        evaluator,
+        snapshot,
+        snapshots={},
+        wap_id=wap_id,
+        observe_result=observed_results.append,
+    )
 
     call_args = adapter_mock.fetchone.call_args_list
     assert len(call_args) == 2
@@ -3328,6 +3356,123 @@ def test_audit_wap(adapter_mock: Mock, make_snapshot: t.Callable[..., Snapshot])
 
     adapter_mock.wap_table_name.assert_called_once_with(snapshot.table_name(), wap_id)
     adapter_mock.wap_publish.assert_called_once_with(snapshot.table_name(), wap_id)
+    assert [result.audit.name for result in observed_results] == ["not_null", "test_audit"]
+
+
+def test_audit_observer_preserves_completed_results_when_a_later_audit_fails(
+    adapter_mock: Mock, make_snapshot: t.Callable[..., Snapshot]
+) -> None:
+    evaluator = SnapshotEvaluator(adapter_mock)
+    model = SqlModel(
+        name="test_schema.test_table",
+        kind=FullKind(),
+        query=parse_one("SELECT a::int FROM tbl"),
+        audits=[
+            ("not_null", {"columns": exp.to_column("a")}),
+            ("unique_values", {"columns": exp.convert(["a"])}),
+        ],
+    )
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    observed_results: t.List[AuditResult] = []
+    fetch_count = 0
+
+    def fetch_audit_result(*args: t.Any, **kwargs: t.Any) -> t.Tuple[int]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 2:
+            assert [result.audit.name for result in observed_results] == ["not_null"]
+            raise RuntimeError("second audit failed")
+        return (0,)
+
+    adapter_mock.fetchone.side_effect = fetch_audit_result
+
+    with pytest.raises(RuntimeError, match="second audit failed"):
+        _audit_observed(
+            evaluator,
+            snapshot,
+            snapshots={},
+            observe_result=observed_results.append,
+        )
+
+    assert [result.audit.name for result in observed_results] == ["not_null"]
+
+
+def test_audit_observer_failure_does_not_abort_remaining_audits(
+    adapter_mock: Mock, make_snapshot: t.Callable[..., Snapshot]
+) -> None:
+    evaluator = SnapshotEvaluator(adapter_mock)
+    model = SqlModel(
+        name="test_schema.test_table",
+        kind=FullKind(),
+        query=parse_one("SELECT a::int, b::int FROM tbl"),
+        audits=[
+            ("not_null", {"columns": exp.to_column("a")}),
+            ("not_null", {"columns": exp.to_column("b")}),
+        ],
+    )
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    adapter_mock.fetchone.return_value = (0,)
+
+    def fail_observer(_result: AuditResult) -> None:
+        raise RuntimeError("observer unavailable")
+
+    results = _audit_observed(
+        evaluator,
+        snapshot,
+        snapshots={},
+        observe_result=fail_observer,
+    )
+
+    assert len(results) == adapter_mock.fetchone.call_count == 2
+
+
+def test_audit_observer_reports_failed_skipped_and_repeated_results_once_in_order(
+    adapter_mock: Mock, make_snapshot: t.Callable[..., Snapshot]
+) -> None:
+    evaluator = SnapshotEvaluator(adapter_mock)
+    skipped_audit = ModelAudit(
+        name="skipped_audit",
+        query="SELECT * FROM test_schema.test_table",
+        skip=True,
+    )
+    model = SqlModel(
+        name="test_schema.test_table",
+        kind=FullKind(),
+        query=parse_one("SELECT a::int, b::int FROM tbl"),
+        audits=[
+            ("not_null", {"columns": exp.to_column("a")}),
+            ("skipped_audit", {}),
+            ("not_null", {"columns": exp.to_column("b")}),
+        ],
+        audit_definitions={skipped_audit.name: skipped_audit},
+    )
+    snapshot = make_snapshot(model)
+    snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+    adapter_mock.fetchone.side_effect = [(2,), (0,)]
+    observed_results: t.List[AuditResult] = []
+
+    returned_results = _audit_observed(
+        evaluator,
+        snapshot,
+        snapshots={},
+        observe_result=observed_results.append,
+    )
+
+    assert observed_results == returned_results
+    assert [result.audit.name for result in observed_results] == [
+        "not_null",
+        "skipped_audit",
+        "not_null",
+    ]
+    assert [result.count for result in observed_results] == [2, None, 0]
+    assert [result.skipped for result in observed_results] == [False, True, False]
+    assert [observed_results[index].audit_args["columns"].sql() for index in (0, 2)] == [
+        "a",
+        "b",
+    ]
+    assert adapter_mock.fetchone.call_count == 2
 
 
 def test_audit_with_datetime_macros(adapter_mock, make_snapshot):
@@ -5050,12 +5195,24 @@ def test_wap_publish_failure(adapter_mock: Mock, make_snapshot: t.Callable[..., 
     adapter_mock.wap_table_name.return_value = expected_wap_table_name
     adapter_mock.fetchone.return_value = (0,)
 
-    # Mock WAP publish to raise an exception
-    adapter_mock.wap_publish.side_effect = Exception("WAP publish failed")
+    observed_results: t.List[AuditResult] = []
 
-    # Execute audit with WAP ID and expect it to raise the exception
-    with pytest.raises(Exception, match="WAP publish failed"):
-        evaluator.audit(snapshot, snapshots={}, wap_id=wap_id)
+    def fail_wap_publish(*args: t.Any, **kwargs: t.Any) -> None:
+        assert [result.audit.name for result in observed_results] == ["not_null"]
+        raise RuntimeError("WAP publish failed")
+
+    adapter_mock.wap_publish.side_effect = fail_wap_publish
+
+    with pytest.raises(RuntimeError, match="WAP publish failed"):
+        _audit_observed(
+            evaluator,
+            snapshot,
+            snapshots={},
+            wap_id=wap_id,
+            observe_result=observed_results.append,
+        )
+
+    assert [result.audit.name for result in observed_results] == ["not_null"]
 
 
 def test_properties_are_preserved_in_both_create_statements(
@@ -5654,3 +5811,50 @@ def test_grants_in_production_with_dev_only_vde(
         # Should still apply grants to physical table when target layer is ALL or PHYSICAL
         sync_grants_mock.assert_called_once()
         assert sync_grants_mock.call_args[0][1] == {"select": ["user1"], "insert": ["role1"]}
+
+
+@pytest.mark.parametrize("workers", [1, 2])
+@pytest.mark.parametrize("operation", ["create", "promote", "demote", "migrate"])
+def test_observation_propagates_through_snapshot_dispatch(
+    mocker, adapter_mock, snapshot, workers, operation
+):
+    from contextvars import ContextVar
+    from sqlmesh.core.execution_observation import observer_scope
+
+    evaluator = SnapshotEvaluator(adapter_mock, ddl_concurrent_tasks=workers)
+    consumer = ContextVar("snapshot_dispatch_consumer", default=None)
+    events = []
+
+    def observer(phase, facts, error):
+        assert consumer.get() == "admission"
+        assert facts["snapshot"] is snapshot
+        events.append((phase, facts["action"], error))
+
+    naming = EnvironmentNamingInfo(name="test")
+    mocker.patch.object(evaluator, "_get_virtual_data_objects", return_value={})
+    mocker.patch.object(
+        evaluator, "_get_physical_data_objects", return_value={snapshot.snapshot_id: mocker.Mock()}
+    )
+    mocker.patch.object(evaluator, "_create_schemas")
+    token = consumer.set("admission")
+    try:
+        with observer_scope(observer):
+            if operation == "create":
+                evaluator._create_snapshots(
+                    [snapshot],
+                    {snapshot.name: snapshot},
+                    DeployabilityIndex.all_deployable(),
+                    None,
+                    set(),
+                    set(),
+                )
+            elif operation == "promote":
+                evaluator.promote([snapshot], naming)
+            elif operation == "demote":
+                evaluator.demote([snapshot], naming)
+            else:
+                evaluator.migrate([snapshot], {snapshot.snapshot_id: snapshot})
+    finally:
+        consumer.reset(token)
+    action = "schema_migration" if operation == "migrate" else operation
+    assert events == [("start", action, None), ("finish", action, None)]


### PR DESCRIPTION
## Description

Add optional start/finish observations for plan stages, model batches, physical and virtual updates, audits, and base-adapter query execution. This extracts a hook used by our execution-recording integration from our SQLMesh fork so consumers can record failures and associate SQL logs without patching execution internals.

Registration uses an optional Console getter or a scoped callback. Each invocation supplies the same read-only native-facts view at start and finish. Ordinary callback errors are isolated, recursive callback observations are suppressed, and worker context propagation is enabled only for observed DAG execution. Consumers own IDs, timing, serialization and storage.

The query hook covers the existing base-adapter log/execute boundary, not transaction completion, result fetching, or every adapter-specific operation. Documentation describes these limits and callback cancellation semantics.

## Test Plan

- [x] `make style`.
- [x] `make fast-test`: 2,812 passed, four skipped; final focused suite after additional execution-path regressions: 348 passed.
- [x] Regression tests for callback identity, reentrancy, failure isolation, disabled behavior, actual plan/scheduler registration, and serial/parallel snapshot dispatch. Five behavioral regressions reproduced against the original fork.
- [x] Unchanged downstream consumer tests against the released fork and candidate: 20 unit/contract/log tests plus five isolated PostgreSQL replay and native DuckDB plan tests per source, zero skips.
- [x] Compared 272 stored action records across four baseline/candidate scenarios: no differences after normalizing generated identities and timing. Action-linked SQL-log chunk/byte counts matched; operation-level fallback log bytes differed and were not treated as equivalent.
- [x] Independent code review.
- [ ] Remote CI.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
