### PR TITLE
fix(web): resolve model paths against their own project root

### DIFF
--- a/tests/web/test_models.py
+++ b/tests/web/test_models.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import pytest

--- a/tests/web/test_models.py
+++ b/tests/web/test_models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlmesh.core.context import Context
+from web.server.api.endpoints.models import get_models
+
+pytestmark = pytest.mark.web
+
+
+def test_get_models_multi_repo() -> None:
+    """Models of every project are serialized, not just those of the first one.
+
+    `context.path` is the first configured project, so it is not an ancestor of the models
+    defined in any of the others.
+    """
+    context = Context(paths=["examples/multi/repo_1", "examples/multi/repo_2"], gateway="memory")
+
+    paths_by_name = {model.name: model.path for model in get_models(context)}
+
+    # Each model is reported relative to the project that defines it.
+    assert paths_by_name["bronze.a"] == "models/a.sql"
+    assert paths_by_name["silver.c"] == "models/c.sql"

--- a/web/server/api/endpoints/models.py
+++ b/web/server/api/endpoints/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlglot import exp
@@ -12,6 +13,7 @@ from sqlmesh.core.model import Model
 from sqlmesh.utils.date import now, to_datetime
 from web.server import models
 from web.server.settings import get_loaded_context
+from web.server.utils import is_relative_to
 
 router = APIRouter()
 
@@ -125,7 +127,7 @@ def serialize_model(context: Context, model: Model, render_query: bool = False) 
     return models.Model(
         name=model.name,
         fqn=model.fqn,
-        path=str(path.absolute().relative_to(context.path).as_posix()) if path else None,
+        path=_path_relative_to_project(context, path) if path else None,
         full_path=str(path.absolute().as_posix()) if path else None,
         dialect=dialect,
         columns=columns,
@@ -136,6 +138,23 @@ def serialize_model(context: Context, model: Model, render_query: bool = False) 
         default_catalog=default_catalog,
         hash=model.data_hash,
     )
+
+
+def _path_relative_to_project(context: Context, path: Path) -> str:
+    """Returns a model's path relative to the project root that defines it.
+
+    `context.path` is only the first of the configured projects, so it isn't necessarily an
+    ancestor of every model when the context is loaded with more than one of them.
+    """
+    absolute_path = path.absolute()
+    project_roots = [root for root in context.configs if is_relative_to(absolute_path, root)]
+    if not project_roots:
+        # The model lives outside of every configured project, so there is nothing to be
+        # relative to.
+        return absolute_path.as_posix()
+    # The deepest root wins so that nested projects report the closest one.
+    closest_root = max(project_roots, key=lambda root: len(root.parts))
+    return absolute_path.relative_to(closest_root).as_posix()
 
 
 def _get_model_type(model: Model) -> str:


### PR DESCRIPTION
## Description

`serialize_model` builds each model's `path` relative to `context.path`, but `context.path` is only the *first* of the configured projects — `Context.__init__` sets it with `next(iter(self.configs.items()))`. When a context is loaded with more than one project, every model outside that first project raises:

```
ValueError: '.../examples/multi/repo_2/models/c.sql' is not in the subpath of '.../examples/multi/repo_1'
```

That is what #5618 reports: with multiple paths in `sqlmesh.projectPaths`, the VSCode lineage panel fails while go-to-definition and the other LSP features keep working. The LSP reaches this endpoint through `sqlmesh/lsp/main.py`, and it is the only place that assumes `context.path` is an ancestor of every model.

This resolves each model against whichever configured project root actually contains it, reusing the existing `web.server.utils.is_relative_to` helper. The deepest matching root wins so that nested projects report the closest one, and a model living outside every configured root falls back to its absolute path instead of raising.

Single-project behaviour is unchanged — `context.path` is then the only entry in `context.configs`, so it is still the root that matches.

## Test Plan

- Added `tests/web/test_models.py::test_get_models_multi_repo`, which loads `examples/multi/repo_1` and `repo_2` and asserts each model reports a path relative to its own project. It fails on `main` with exactly the `ValueError` above, and passes with this change.
- `pytest tests/web` — 65 passed, 2 skipped. That includes `test_get_model`, which asserts `path == "models/customers.sql"` for the single-project sushi project, so the unchanged behaviour is covered.
- `pytest tests/lsp` — 61 passed.
- `make fast-test` — 2224 passed. The remaining failures are all environmental on my machine and none are in a code path this touches: optional engine/dbt/GitHub extras I don't have installed (`snowflake`, `pyspark`, `agate`, `PyGithub`, trino/clickhouse), plus an old local git that doesn't support `git init -b`.
- `pre-commit run --files web/server/api/endpoints/models.py tests/web/test_models.py` — ruff, ruff-format and the migration check pass. mypy reports the same 74 errors with and without this change (missing third-party stubs in my local environment); none of them are in the touched files.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
