### PR TITLE
feat(lint): accept model file paths in the lint command

### DIFF
--- a/docs/guides/linter.md
+++ b/docs/guides/linter.md
@@ -127,6 +127,29 @@ Error: Linter detected errors in the code. Please fix them before proceeding.
 
 Use `sqlmesh lint --help` for more information.
 
+Models can be selected by name with `--model`, by model file path, or by both at once. Selecting by
+path lets `sqlmesh lint` be wired up to path-based tooling such as [pre-commit](https://pre-commit.com/),
+which passes the names of the changed files:
+
+``` bash
+$ sqlmesh lint models/full_model.sql models/incremental_model.sql
+```
+
+``` yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: sqlmesh-lint
+        name: sqlmesh lint
+        entry: sqlmesh lint --local --use-project-index
+        language: system
+        files: ^models/.*\.(sql|py)$
+```
+
+SQLMesh errors if a path doesn't define any models, so a stale or mistyped path fails loudly instead
+of silently linting the whole project.
+
 You can pass `--local` to run lint without loading state from the configured state connection:
 
 ``` bash
@@ -136,9 +159,9 @@ $ sqlmesh lint --local
 This can make linting faster in repositories where all referenced models are loaded from local files. In multi-repository setups, or when linting only a subset of projects, `--local` may cause additional linting errors because SQLMesh will not resolve references or schemas from models that exist only in remote state.
 
 For faster targeted linting, enable the persistent project index with `--use-project-index`. When
-models are selected with `--model`, SQLMesh loads, resolves, and validates only those models and
-their transitive upstream dependencies. The same behavior can be enabled by default for the
-Python API and CLI with the `linter.use_project_index` configuration option:
+models are selected with `--model` or by file path, SQLMesh loads, resolves, and validates only those
+models and their transitive upstream dependencies. The same behavior can be enabled by default for
+the Python API and CLI with the `linter.use_project_index` configuration option:
 
 ```yaml
 linter:
@@ -148,7 +171,8 @@ linter:
 
 `Context.lint_models` uses this configuration value when `use_project_index` is omitted. Passing
 `use_project_index=False` explicitly disables it for that call. If a context was already loaded,
-an indexed lint of selected models reloads the context so the requested scope is applied.
+an indexed lint of selected models reloads the context so the requested scope is applied. Model
+file paths can be passed to `Context.lint_models` with the `paths` argument.
 
 
 ## Applying linting rules

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -650,7 +650,9 @@ Options:
 ## lint
 ```
 Usage: sqlmesh lint [OPTIONS] [PATHS]...
-  Run linter for the target model(s). Models can be selected by name with --model, by model file path, or by both.
+  Run the linter for the target model(s).
+
+  Models can be selected by name with --model, by model file path, or by both.
 
 Options:
   --model TEXT           A model to lint. Multiple models can be linted.  If no models or paths are specified, every model will be

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -649,14 +649,15 @@ Options:
 
 ## lint
 ```
-Usage: sqlmesh lint [OPTIONS]
-  Run linter for the target model(s).
+Usage: sqlmesh lint [OPTIONS] [PATHS]...
+  Run linter for the target model(s). Models can be selected by name with --model, by model file path, or by both.
 
 Options:
-  --model TEXT           A model to lint. Multiple models can be linted.  If no models are specified, every model will be linted.
-  --use-project-index    Use the persistent project index. With --model, only the selected models and their upstream dependencies
-                         are loaded, resolved, and validated, so errors in unrelated models are not reported. Without --model,
-                         every model is still loaded and linted.
+  --model TEXT           A model to lint. Multiple models can be linted.  If no models or paths are specified, every model will be
+                         linted.
+  --use-project-index    Use the persistent project index. With --model or model file paths, only the selected models and their
+                         upstream dependencies are loaded, resolved, and validated, so errors in unrelated models are not reported.
+                         Without a selection, every model is still loaded and linted.
   --local                Lint using only locally loaded project files without loading state. In multi-repository setups, or when
                          linting only a subset of projects, this may cause additional linting errors because SQLMesh will not resolve
                          references or schemas from models that exist only in remote state.

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -1224,17 +1224,18 @@ def environments(obj: Context) -> None:
 
 
 @cli.command("lint")
+@click.argument("paths", nargs=-1)
 @click.option(
     "--models",
     "--model",
     multiple=True,
-    help="A model to lint. Multiple models can be linted. If no models are specified, every model will be linted.",
+    help="A model to lint. Multiple models can be linted. If no models or paths are specified, every model will be linted.",
 )
 @click.option(
     "--use-project-index",
     is_flag=True,
     default=None,
-    help="Use the persistent project index. With --model, only the selected models and their upstream dependencies are loaded, resolved, and validated, so errors in unrelated models are not reported. Without --model, every model is still loaded and linted. Can also be enabled with linter.use_project_index.",
+    help="Use the persistent project index. With --model or model file paths, only the selected models and their upstream dependencies are loaded, resolved, and validated, so errors in unrelated models are not reported. Without a selection, every model is still loaded and linted. Can also be enabled with linter.use_project_index.",
 )
 @click.option(
     "--local",
@@ -1247,6 +1248,7 @@ def environments(obj: Context) -> None:
 @cli_analytics
 def lint(
     obj: Context,
+    paths: t.Tuple[str, ...],
     models: t.Iterator[str],
     use_project_index: t.Optional[bool],
 ) -> None:
@@ -1254,6 +1256,7 @@ def lint(
     obj.lint_models(
         models,
         use_project_index=use_project_index,
+        paths=paths,
     )
 
     if not obj.models:

--- a/sqlmesh/cli/main.py
+++ b/sqlmesh/cli/main.py
@@ -1252,7 +1252,10 @@ def lint(
     models: t.Iterator[str],
     use_project_index: t.Optional[bool],
 ) -> None:
-    """Run the linter for the target model(s)."""
+    """Run the linter for the target model(s).
+
+    Models can be selected by name with --model, by model file path, or by both.
+    """
     obj.lint_models(
         models,
         use_project_index=use_project_index,

--- a/sqlmesh/core/context.py
+++ b/sqlmesh/core/context.py
@@ -648,6 +648,7 @@ class GenericContext(BaseContext, t.Generic[C]):
         update_schemas: bool = True,
         model_fqns: t.Optional[t.Set[str]] = None,
         use_project_index: bool = False,
+        model_paths: t.Optional[t.Set[Path]] = None,
     ) -> GenericContext[C]:
         """Load files in the context's path, optionally scoped to specific models.
 
@@ -656,8 +657,10 @@ class GenericContext(BaseContext, t.Generic[C]):
             model_fqns: If provided with ``use_project_index=True``, only the selected models
                 and their transitive upstream dependencies are loaded.
             use_project_index: Whether to use and maintain the persistent project model index.
-                When ``model_fqns`` is not provided, all models are loaded and the index is
-                refreshed for future scoped loads.
+                When neither ``model_fqns`` nor ``model_paths`` is provided, all models are
+                loaded and the index is refreshed for future scoped loads.
+            model_paths: Resolved model file paths to select models with, in addition to
+                ``model_fqns``.
         """
         load_start_ts = time.perf_counter()
 
@@ -665,6 +668,7 @@ class GenericContext(BaseContext, t.Generic[C]):
             loader.load(
                 model_fqns=model_fqns,
                 use_project_index=use_project_index,
+                model_paths=model_paths,
             )
             for loader in self._loaders
         ]
@@ -713,8 +717,9 @@ class GenericContext(BaseContext, t.Generic[C]):
         indexed_model_fqns = {
             fqn for project in loaded_projects for fqn in (project.indexed_model_fqns or set())
         }
-        if model_fqns and (
-            not model_fqns <= self._models.keys()
+        if (model_fqns or model_paths) and (
+            not (model_fqns or set()) <= self._models.keys()
+            or (model_paths is not None and not model_paths <= self._loaded_model_paths())
             or any(
                 dependency in indexed_model_fqns and dependency not in self._models
                 for model in self._models.values()
@@ -728,7 +733,9 @@ class GenericContext(BaseContext, t.Generic[C]):
                 use_project_index=use_project_index,
             )
             if update_schemas:
-                self._update_model_schemas_and_validate(model_fqns)
+                self._update_model_schemas_and_validate(
+                    self._selected_model_fqns(model_fqns, model_paths)
+                )
             return self
 
         # Load environment statements from state for projects not in current load
@@ -762,7 +769,9 @@ class GenericContext(BaseContext, t.Generic[C]):
             self.dag.add(model.fqn, model.depends_on)
 
         if update_schemas:
-            self._update_model_schemas_and_validate(model_fqns or None)
+            self._update_model_schemas_and_validate(
+                self._selected_model_fqns(model_fqns, model_paths) or None
+            )
 
         duplicates = set(self._models) & set(self._standalone_audits)
         if duplicates:
@@ -788,6 +797,25 @@ class GenericContext(BaseContext, t.Generic[C]):
 
         self._loaded = True
         return self
+
+    def _loaded_model_paths(self) -> t.Set[Path]:
+        """The resolved file paths of every loaded model that was defined in a file."""
+        return {model._path.resolve() for model in self._models.values() if model._path is not None}
+
+    def _selected_model_fqns(
+        self,
+        model_fqns: t.Optional[t.Set[str]] = None,
+        model_paths: t.Optional[t.Set[Path]] = None,
+    ) -> t.Set[str]:
+        """The FQNs of the loaded models selected by name and/or by file path."""
+        selected = set(model_fqns or set())
+        if model_paths:
+            selected.update(
+                model.fqn
+                for model in self._models.values()
+                if model._path is not None and model._path.resolve() in model_paths
+            )
+        return selected
 
     def _update_model_schemas_and_validate(self, model_fqns: t.Optional[t.Set[str]] = None) -> None:
         """Updates the mapping schemas of the given models (all models by default) and validates their definitions.
@@ -3546,25 +3574,65 @@ class GenericContext(BaseContext, t.Generic[C]):
             )
         return models_for_interval_end
 
+    def _models_for_paths(self, paths: t.List[Path]) -> t.List[Model]:
+        """Resolves model file paths to the loaded models defined in them.
+
+        Raises:
+            SQLMeshError: If any of the paths doesn't define a model.
+        """
+        models_by_path: t.Dict[Path, t.List[Model]] = collections.defaultdict(list)
+        for model in self._models.values():
+            if model._path is not None:
+                models_by_path[model._path.resolve()].append(model)
+
+        models = []
+        unknown_paths = []
+        for path in paths:
+            path_models = models_by_path.get(path.resolve())
+            if path_models:
+                models.extend(path_models)
+            else:
+                unknown_paths.append(str(path))
+
+        if unknown_paths:
+            raise SQLMeshError(
+                f"No models were found at the following path(s): {', '.join(unknown_paths)}"
+            )
+
+        return models
+
     def lint_models(
         self,
         models: t.Optional[t.Iterable[t.Union[str, Model]]] = None,
         raise_on_error: bool = True,
         use_project_index: t.Optional[bool] = None,
+        paths: t.Optional[t.Iterable[t.Union[str, Path]]] = None,
     ) -> t.List[AnnotatedRuleViolation]:
         """Lint the selected models.
 
         Args:
-            models: Models to lint. If omitted, all loaded models are linted.
+            models: Models to lint. If omitted and no paths are given, all loaded models are linted.
             raise_on_error: Whether to raise when an error-level violation is found.
             use_project_index: Whether to use the persistent project index. If omitted, the
                 value of ``linter.use_project_index`` is used. Indexed linting of selected
                 models reloads an already-loaded context so the requested scope is applied.
+            paths: Model file paths to lint, each resolved to the model(s) defined in it. Can be
+                combined with `models`.
         """
         models = list(models) if models is not None else []
+        target_paths = [Path(path) for path in paths] if paths is not None else []
+
+        # Fail fast on a mistyped path instead of loading and linting the whole project.
+        missing_paths = [str(path) for path in target_paths if not path.is_file()]
+        if missing_paths:
+            raise SQLMeshError(
+                f"No models were found at the following path(s): {', '.join(missing_paths)}"
+            )
+
         use_project_index = (
             self.config.linter.use_project_index if use_project_index is None else use_project_index
         )
+        scoped = use_project_index and bool(models or target_paths)
 
         target_fqns = (
             {
@@ -3577,22 +3645,37 @@ class GenericContext(BaseContext, t.Generic[C]):
                 else model.fqn
                 for model in models
             }
-            if models and use_project_index
+            if scoped
             else None
+        )
+        target_model_paths = (
+            {path.resolve() for path in target_paths} if scoped and target_paths else None
         )
 
         # An already-loaded context does not otherwise enter the loading path. Reload when
         # indexed linting is requested for specific models so the scope is actually applied.
-        if not self._loaded or target_fqns is not None:
-            self.load(model_fqns=target_fqns, use_project_index=use_project_index)
+        if not self._loaded or scoped:
+            self.load(
+                model_fqns=target_fqns,
+                use_project_index=use_project_index,
+                model_paths=target_model_paths,
+            )
 
         found_error = False
 
-        model_list = (
-            list(self.get_model(model, raise_if_missing=True) for model in models)
-            if models
-            else self.models.values()
-        )
+        model_list: t.Iterable[Model]
+        if models or target_paths:
+            # A model selected both by name and by path must only be linted once.
+            selected_models: t.Dict[str, Model] = {}
+            for model in models:
+                selected_model = self.get_model(model, raise_if_missing=True)
+                selected_models[selected_model.fqn] = selected_model
+            for selected_model in self._models_for_paths(target_paths):
+                selected_models[selected_model.fqn] = selected_model
+            model_list = selected_models.values()
+        else:
+            model_list = self.models.values()
+
         all_violations = []
         for model in model_list:
             # Linter may be `None` if the context is not loaded yet

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -196,6 +196,7 @@ class Loader(abc.ABC):
         self,
         model_fqns: t.Optional[t.Set[str]] = None,
         use_project_index: bool = False,
+        model_paths: t.Optional[t.Set[Path]] = None,
     ) -> LoadedProject:
         """
         Loads all macros and models in the context's path.
@@ -204,6 +205,8 @@ class Loader(abc.ABC):
             model_fqns: Optional model names to load. Loaders that support partial loading
                 also include these models' transitive upstream dependencies.
             use_project_index: Whether to use and maintain the persistent project model index.
+            model_paths: Optional resolved model file paths to load, treated the same way as
+                `model_fqns` by loaders that support partial loading.
 
         Returns:
             A loaded project object.
@@ -249,6 +252,7 @@ class Loader(abc.ABC):
                 signals,
                 model_fqns,
                 use_project_index,
+                model_paths,
             )
 
             metrics = self._load_metrics()
@@ -304,6 +308,7 @@ class Loader(abc.ABC):
         signals: UniqueKeyDict[str, signal],
         model_fqns: t.Optional[t.Set[str]] = None,
         use_project_index: bool = False,
+        model_paths: t.Optional[t.Set[Path]] = None,
     ) -> t.Tuple[UniqueKeyDict[str, Model], t.Optional[t.Set[str]]]:
         """Loads all models."""
 
@@ -557,6 +562,7 @@ class SqlMeshLoader(Loader):
         signals: UniqueKeyDict[str, signal],
         model_fqns: t.Optional[t.Set[str]] = None,
         use_project_index: bool = False,
+        model_paths: t.Optional[t.Set[Path]] = None,
     ) -> t.Tuple[UniqueKeyDict[str, Model], t.Optional[t.Set[str]]]:
         """
         Loads all of the models within the model directory with their associated
@@ -564,7 +570,9 @@ class SqlMeshLoader(Loader):
         """
         cache = SqlMeshLoader._Cache(self, self.config_path)
         selected_model_index = (
-            self._selected_model_paths(model_fqns) if use_project_index and model_fqns else None
+            self._selected_model_paths(model_fqns or set(), model_paths)
+            if use_project_index and (model_fqns or model_paths)
+            else None
         )
         selected_paths, indexed_model_fqns = selected_model_index or (None, None)
 
@@ -634,7 +642,7 @@ class SqlMeshLoader(Loader):
         return paths
 
     def _selected_model_paths(
-        self, model_fqns: t.Set[str]
+        self, model_fqns: t.Set[str], model_paths: t.Optional[t.Set[Path]] = None
     ) -> t.Optional[t.Tuple[t.Set[Path], t.Set[str]]]:
         try:
             index = json.loads(self._model_index_path.read_text(encoding="utf-8"))
@@ -674,6 +682,10 @@ class SqlMeshLoader(Loader):
                 dependencies[fqn] = set(depends_on)
 
         selected = {fqn for fqn in model_fqns if fqn in model_to_path}
+        if model_paths:
+            selected.update(
+                fqn for fqn, path in model_to_path.items() if path.resolve() in model_paths
+            )
         stack = list(selected)
         while stack:
             fqn = stack.pop()

--- a/sqlmesh/core/loader.py
+++ b/sqlmesh/core/loader.py
@@ -667,7 +667,13 @@ class SqlMeshLoader(Loader):
         if current_paths != indexed_paths:
             return None
 
+        # The caller resolves the paths it selects with, so the index side is keyed by a
+        # resolved path too. Resolving the project root once keeps that to a single
+        # filesystem call instead of one per indexed model.
+        resolved_config_path = self.config_path.resolve() if model_paths else self.config_path
+
         model_to_path: t.Dict[str, Path] = {}
+        fqns_by_resolved_path: t.Dict[Path, t.Set[str]] = defaultdict(set)
         dependencies: t.Dict[str, t.Set[str]] = {}
         for relative_path, file_models in indexed_files.items():
             path = self.config_path / relative_path
@@ -680,11 +686,23 @@ class SqlMeshLoader(Loader):
                     return None
                 model_to_path[fqn] = path
                 dependencies[fqn] = set(depends_on)
+                if model_paths:
+                    fqns_by_resolved_path[resolved_config_path / relative_path].add(fqn)
 
         selected = {fqn for fqn in model_fqns if fqn in model_to_path}
-        if model_paths:
+        unmatched_paths = set()
+        for model_path in model_paths or set():
+            matched = fqns_by_resolved_path.get(model_path)
+            if matched:
+                selected.update(matched)
+            else:
+                unmatched_paths.add(model_path)
+        if unmatched_paths:
+            # Joining onto the resolved project root misses a model file that is itself a
+            # symlink, so fall back to resolving each indexed path for the few that are
+            # still unaccounted for.
             selected.update(
-                fqn for fqn, path in model_to_path.items() if path.resolve() in model_paths
+                fqn for fqn, path in model_to_path.items() if path.resolve() in unmatched_paths
             )
         stack = list(selected)
         while stack:

--- a/sqlmesh/dbt/loader.py
+++ b/sqlmesh/dbt/loader.py
@@ -137,11 +137,13 @@ class DbtLoader(Loader):
         self,
         model_fqns: t.Optional[t.Set[str]] = None,
         use_project_index: bool = False,
+        model_paths: t.Optional[t.Set[Path]] = None,
     ) -> LoadedProject:
         self._projects = []
         return super().load(
             model_fqns=model_fqns,
             use_project_index=use_project_index,
+            model_paths=model_paths,
         )
 
     def _load_scripts(self) -> t.Tuple[MacroRegistry, JinjaMacroRegistry]:
@@ -165,6 +167,7 @@ class DbtLoader(Loader):
         signals: UniqueKeyDict[str, signal],
         model_fqns: t.Optional[t.Set[str]] = None,
         use_project_index: bool = False,
+        model_paths: t.Optional[t.Set[Path]] = None,
     ) -> t.Tuple[UniqueKeyDict[str, Model], t.Optional[t.Set[str]]]:
         models: UniqueKeyDict[str, Model] = UniqueKeyDict("models")
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1476,6 +1476,117 @@ def test_lint(runner, tmp_path):
     assert result.exit_code == 1
 
 
+def test_lint_paths(runner, tmp_path):
+    create_example_project(tmp_path)
+
+    with open(tmp_path / "config.yaml", "a", encoding="utf-8") as f:
+        f.write(
+            """linter:
+    enabled: True
+    rules: "ALL"
+"""
+        )
+
+    # A single model file only lints that model.
+    result = runner.invoke(
+        cli, ["--paths", tmp_path, "lint", str(tmp_path / "models" / "seed_model.sql")]
+    )
+    assert result.output.count("Linter errors for") == 1
+    assert "seed_model.sql" in result.output
+    assert result.exit_code == 1
+
+    # Multiple model files can be passed, as pre-commit does.
+    result = runner.invoke(
+        cli,
+        [
+            "--paths",
+            tmp_path,
+            "lint",
+            str(tmp_path / "models" / "seed_model.sql"),
+            str(tmp_path / "models" / "incremental_model.sql"),
+        ],
+    )
+    assert result.output.count("Linter errors for") == 2
+    assert result.exit_code == 1
+
+    # Paths and --model can be combined, and overlapping selections lint once.
+    result = runner.invoke(
+        cli,
+        [
+            "--paths",
+            tmp_path,
+            "lint",
+            "--model",
+            "sqlmesh_example.seed_model",
+            str(tmp_path / "models" / "seed_model.sql"),
+            str(tmp_path / "models" / "incremental_model.sql"),
+        ],
+    )
+    assert result.output.count("Linter errors for") == 2
+    assert result.exit_code == 1
+
+    # `--local` and `--use-project-index` keep working alongside paths.
+    result = runner.invoke(
+        cli,
+        [
+            "--paths",
+            tmp_path,
+            "lint",
+            "--local",
+            "--use-project-index",
+            str(tmp_path / "models" / "seed_model.sql"),
+        ],
+    )
+    assert result.output.count("Linter errors for") == 1
+    assert result.exit_code == 1
+
+
+def test_lint_relative_path(runner, tmp_path, monkeypatch):
+    create_example_project(tmp_path)
+
+    with open(tmp_path / "config.yaml", "a", encoding="utf-8") as f:
+        f.write(
+            """linter:
+    enabled: True
+    rules: "ALL"
+"""
+        )
+
+    # Path-based tools such as pre-commit pass paths relative to the project root.
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(cli, ["--paths", tmp_path, "lint", "models/seed_model.sql"])
+    assert result.output.count("Linter errors for") == 1
+    assert "seed_model.sql" in result.output
+    assert result.exit_code == 1
+
+
+def test_lint_unknown_path(runner, tmp_path):
+    create_example_project(tmp_path)
+
+    with open(tmp_path / "config.yaml", "a", encoding="utf-8") as f:
+        f.write(
+            """linter:
+    enabled: True
+    rules: "ALL"
+"""
+        )
+
+    # An unknown path errors out instead of falling back to linting the whole project.
+    result = runner.invoke(
+        cli, ["--paths", tmp_path, "lint", str(tmp_path / "models" / "missing.sql")]
+    )
+    assert result.exit_code == 1
+    assert "No models were found at the following path(s)" in result.output
+    assert "Linter errors for" not in result.output
+
+    # A file that exists but defines no models is an error too.
+    audit_path = tmp_path / "audits" / "assert_positive_order_ids.sql"
+    result = runner.invoke(cli, ["--paths", tmp_path, "lint", str(audit_path)])
+    assert result.exit_code == 1
+    assert "No models were found at the following path(s)" in result.output
+    assert "Linter errors for" not in result.output
+
+
 def test_lint_no_models(runner, tmp_path):
     with open(tmp_path / "config.yaml", "w", encoding="utf-8") as f:
         f.write("model_defaults:\n  dialect: duckdb\n")
@@ -1515,6 +1626,22 @@ def test_lint_model_scopes_validation_with_multiple_projects(runner, tmp_path):
             "--use-project-index",
             "--model",
             "selected",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    # Selecting the same model by path scopes the load the same way.
+    result = runner.invoke(
+        cli,
+        [
+            "--paths",
+            project_a,
+            "--paths",
+            project_b,
+            "lint",
+            "--use-project-index",
+            str(project_a / "models" / "selected.sql"),
         ],
     )
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -3404,6 +3404,136 @@ def test_lint_models_scoped_schema_resolution(tmp_path: pathlib.Path) -> None:
     assert set(schemas_mock.call_args.kwargs["models"]) == set(ctx.models)
 
 
+def test_lint_models_by_path(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def create_context() -> Context:
+        return Context(
+            config=Config(
+                model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+                linter=LinterConfig(enabled=True, rules=["noselectstar"]),
+            ),
+            paths=tmp_path,
+            load=False,
+        )
+
+    sql_path = create_temp_file(
+        tmp_path, pathlib.Path("models", "a.sql"), "MODEL(name a); SELECT 1 AS col;"
+    )
+    violating_path = create_temp_file(
+        tmp_path, pathlib.Path("models", "b.sql"), "MODEL(name b); SELECT * FROM a;"
+    )
+    python_path = create_temp_file(
+        tmp_path,
+        pathlib.Path("models", "c.py"),
+        """import typing as t
+import pandas as pd
+from sqlmesh import ExecutionContext, model
+
+@model("c", columns={"col": "int"})
+def execute(context: ExecutionContext, **kwargs: t.Any) -> pd.DataFrame:
+    return pd.DataFrame({"col": [1]})
+""",
+    )
+
+    # Case: a path selects only the models defined in that file.
+    ctx = create_context()
+    violations = ctx.lint_models(paths=[violating_path], raise_on_error=False)
+    assert [violation.model.name for violation in violations] == ["b"]
+
+    # Case: linting an unrelated file doesn't report the violation in b.sql.
+    assert create_context().lint_models(paths=[sql_path]) == []
+
+    # Case: Python model files are selectable too.
+    assert create_context().lint_models(paths=[python_path]) == []
+
+    # Case: relative paths are resolved against the current working directory.
+    monkeypatch.chdir(tmp_path)
+    assert create_context().lint_models(paths=[pathlib.Path("models", "c.py")]) == []
+
+    # Case: paths and names can be combined, and a model selected by both is linted once.
+    ctx = create_context()
+    violations = ctx.lint_models(["b"], paths=[violating_path, sql_path], raise_on_error=False)
+    assert [violation.model.name for violation in violations] == ["b"]
+
+    # Case: an unknown path is an error rather than a silent full-project lint.
+    unknown_path = tmp_path / "models" / "missing.sql"
+    with pytest.raises(SQLMeshError, match="No models were found at the following path\\(s\\)"):
+        create_context().lint_models(paths=[unknown_path])
+
+    # Case: an error-level violation still raises when selected by path.
+    with pytest.raises(
+        LinterError, match="Linter detected errors in the code. Please fix them before proceeding."
+    ):
+        create_context().lint_models(paths=[violating_path])
+
+
+def test_lint_models_by_path_with_project_index(tmp_path: pathlib.Path) -> None:
+    def create_context() -> Context:
+        return Context(
+            config=Config(
+                model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+                linter=LinterConfig(enabled=True, rules=["noselectstar"]),
+            ),
+            paths=tmp_path,
+            load=False,
+        )
+
+    create_temp_file(
+        tmp_path,
+        pathlib.Path("models", "a.sql"),
+        "MODEL(name a); SELECT 1 AS col FROM raw.unregistered_source;",
+    )
+    target_path = create_temp_file(
+        tmp_path, pathlib.Path("models", "b.sql"), "MODEL(name b); SELECT col FROM a;"
+    )
+    create_temp_file(tmp_path, pathlib.Path("models", "c.sql"), "MODEL(name c); SELECT * FROM b;")
+
+    # The initial full file load also creates the index.
+    assert create_context().lint_models(paths=[target_path], use_project_index=True) == []
+
+    ctx = create_context()
+    loader = t.cast(SqlMeshLoader, ctx._loaders[0])
+    with patch.object(loader, "_load_sql_models", wraps=loader._load_sql_models) as load_mock:
+        assert ctx.lint_models(paths=[target_path], use_project_index=True) == []
+
+    # Only the target file and its upstream dependencies are loaded off the index.
+    assert load_mock.call_count == 1
+    selected_paths = load_mock.call_args.kwargs["selected_paths"]
+    assert {path.name for path in selected_paths} == {"a.sql", "b.sql"}
+    assert set(ctx.models) == {
+        ctx.get_model(model_name, raise_if_missing=True).fqn for model_name in ("a", "b")
+    }
+
+    # Case: an unknown path is rejected off the index, before any models are loaded.
+    ctx = create_context()
+    loader = t.cast(SqlMeshLoader, ctx._loaders[0])
+    with patch.object(loader, "_load_sql_models", wraps=loader._load_sql_models) as load_mock:
+        with pytest.raises(SQLMeshError, match="No models were found at the following path\\(s\\)"):
+            ctx.lint_models(paths=[tmp_path / "models" / "missing.sql"], use_project_index=True)
+
+    assert load_mock.call_count == 0
+
+
+def test_lint_models_by_path_without_index_falls_back_to_full_load(tmp_path: pathlib.Path) -> None:
+    create_temp_file(tmp_path, pathlib.Path("models", "a.sql"), "MODEL(name a); SELECT 1 AS col;")
+    target_path = create_temp_file(
+        tmp_path, pathlib.Path("models", "b.sql"), "MODEL(name b); SELECT col FROM a;"
+    )
+
+    context = Context(
+        config=Config(
+            model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+            linter=LinterConfig(enabled=True, rules=["noselectstar"]),
+        ),
+        paths=tmp_path,
+        load=False,
+    )
+    loader = t.cast(SqlMeshLoader, context._loaders[0])
+    with patch.object(loader, "_load_sql_models", wraps=loader._load_sql_models) as load_mock:
+        assert context.lint_models(paths=[target_path], use_project_index=True) == []
+
+    assert load_mock.call_args.kwargs["selected_paths"] is None
+
+
 def test_lint_models_project_index_reloads_loaded_context(tmp_path: pathlib.Path) -> None:
     create_temp_file(tmp_path, pathlib.Path("models", "a.sql"), "MODEL(name a); SELECT 1 AS col;")
     create_temp_file(tmp_path, pathlib.Path("models", "b.sql"), "MODEL(name b); SELECT col FROM a;")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import pathlib
 import typing as t
 import re
@@ -3511,6 +3512,84 @@ def test_lint_models_by_path_with_project_index(tmp_path: pathlib.Path) -> None:
             ctx.lint_models(paths=[tmp_path / "models" / "missing.sql"], use_project_index=True)
 
     assert load_mock.call_count == 0
+
+
+def test_lint_models_by_path_with_project_index_resolves_only_given_paths(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Matching a path off the index must not stat every model in the project."""
+
+    def create_context() -> Context:
+        return Context(
+            config=Config(
+                model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+                linter=LinterConfig(enabled=True, rules=["noselectstar"]),
+            ),
+            paths=tmp_path,
+            load=False,
+        )
+
+    for name in ("a", "b", "c", "d", "e"):
+        create_temp_file(
+            tmp_path, pathlib.Path("models", f"{name}.sql"), f"MODEL(name {name}); SELECT 1 AS col;"
+        )
+    target_path = tmp_path / "models" / "a.sql"
+
+    # The initial full file load also creates the index and primes the loader's state.
+    ctx = create_context()
+    assert ctx.lint_models(paths=[target_path], use_project_index=True) == []
+
+    loader = t.cast(SqlMeshLoader, ctx._loaders[0])
+    original_resolve = pathlib.Path.resolve
+    resolved: t.List[pathlib.Path] = []
+
+    def counting_resolve(self: pathlib.Path, *args: t.Any, **kwargs: t.Any) -> pathlib.Path:
+        resolved.append(self)
+        return original_resolve(self, *args, **kwargs)
+
+    resolved_target_path = target_path.resolve()
+    with patch.object(pathlib.Path, "resolve", counting_resolve):
+        selected_paths, _ = t.cast(
+            t.Tuple[t.Set[pathlib.Path], t.Set[str]],
+            loader._selected_model_paths(set(), {resolved_target_path}),
+        )
+
+    assert {path.name for path in selected_paths} == {"a.sql"}
+    # The project root is resolved, but never one path per indexed model.
+    assert [path for path in resolved if path.suffix == ".sql"] == []
+
+
+def test_lint_models_by_path_with_project_index_symlinked_model_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A model file that is itself a symlink is still matched against the index."""
+    create_temp_file(tmp_path, pathlib.Path("models", "a.sql"), "MODEL(name a); SELECT 1 AS col;")
+    external_path = create_temp_file(
+        tmp_path, pathlib.Path("external", "b.sql"), "MODEL(name b); SELECT col FROM a;"
+    )
+    link_path = tmp_path / "models" / "b.sql"
+    os.symlink(external_path, link_path)
+
+    def create_context() -> Context:
+        return Context(
+            config=Config(
+                model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+                linter=LinterConfig(enabled=True, rules=["noselectstar"]),
+            ),
+            paths=tmp_path,
+            load=False,
+        )
+
+    # The initial full file load also creates the index.
+    assert create_context().lint_models(paths=[link_path], use_project_index=True) == []
+
+    ctx = create_context()
+    loader = t.cast(SqlMeshLoader, ctx._loaders[0])
+    with patch.object(loader, "_load_sql_models", wraps=loader._load_sql_models) as load_mock:
+        assert ctx.lint_models(paths=[link_path], use_project_index=True) == []
+
+    selected_paths = load_mock.call_args.kwargs["selected_paths"]
+    assert {path.name for path in selected_paths} == {"a.sql", "b.sql"}
 
 
 def test_lint_models_by_path_without_index_falls_back_to_full_load(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Description

Closes #6021.

`sqlmesh lint` could only select models by name with `--model`, so path-based tooling such as [pre-commit](https://pre-commit.com/) — which passes the names of the changed files — could not drive it without a wrapper that mapped paths back to model names.

This adds a positional `PATHS` argument to `sqlmesh lint`, mirroring the shape of `sqlmesh format`:

```bash
sqlmesh lint --local --use-project-index models/a.sql models/b.py
```

Behaviour:

- Each path is resolved to the model(s) defined in that file. SQL and Python model files both work.
- Paths can be combined with `--model`. A model selected both ways is linted once.
- No paths and no `--model` still lints every model, unchanged.
- A path that defines no model (a typo, a non-model file) is rejected with a clear error instead of silently falling back to linting the whole project:
  ```
  Error: No models were found at the following path(s): models/typo.sql
  ```
- `--local` and `--use-project-index` keep working when the selection comes from paths.

### Implementation note

`--use-project-index` needs the paths *before* models are parsed, so that only the selected files and their upstream dependencies are loaded. The persistent index can only be read from inside `Loader.load()` (`_model_index_id()` depends on the macro/signal/audit mtimes that the load tracks), so rather than resolving paths up front, the selected paths are plumbed through `Context.load` → `Loader.load` → `_load_models` alongside the existing `model_fqns`. `SqlMeshLoader._selected_model_paths` then seeds its selection from both the requested FQNs and the requested paths, and the existing upstream-closure and stale-index fallbacks apply unchanged.

The final model set is always resolved from the loaded models via `Model._path`, which is what produces the "no models at this path" error and keeps the multi-project case (one `Loader` per `--paths`) correct.

## Test Plan

New tests:

- `tests/core/test_context.py::test_lint_models_by_path` — a path selects only the models in that file; unrelated violations are not reported; Python model files work; relative paths resolve against the cwd; paths and `--model` combine and de-duplicate; an unknown path raises; error-level violations still raise.
- `tests/core/test_context.py::test_lint_models_by_path_with_project_index` — asserts `_load_sql_models` is called with `selected_paths == {a.sql, b.sql}` for a path-selected model with one upstream, and that an unknown path is rejected before any models are loaded.
- `tests/core/test_context.py::test_lint_models_by_path_without_index_falls_back_to_full_load` — a missing index falls back to a full load.
- `tests/cli/test_cli.py::test_lint_paths`, `test_lint_relative_path`, `test_lint_unknown_path` — CLI coverage for single/multiple paths, paths plus `--model`, relative paths, `--local`/`--use-project-index`, and both unknown-path cases.
- `tests/cli/test_cli.py::test_lint_model_scopes_validation_with_multiple_projects` — extended to cover selecting the same model by path in a multi-project context.

Also verified by hand on a fresh `sqlmesh init duckdb` project with `rules: "ALL"` and an added `SELECT *` model: linting a single file reports only that model, linting with no arguments still reports all three, an unknown path and an audit file both error out, and `--use-project-index` produces the same result on the run that builds the index and on the run that reads it.

`make fast-test` passes (2619 passed). The 5 pre-existing failures in `tests/utils/test_git_client.py` and `test_expand_git_selection_integration` reproduce identically on an unmodified checkout in my environment and are unrelated to this change.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
