### PR TITLE
ci: turn on and fix `ui-style` and `test-vscode` stages

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,10 +11,7 @@
   "postCreateCommand": "bash .devcontainer/post-create-command.sh",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "ms-python.python",
-        "ms-python.vscode-pylance"
-      ]
+      "extensions": ["ms-python.python", "ms-python.vscode-pylance"]
     }
   },
   "remoteUser": "vscode"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       python: ${{ steps.filter.outputs.python }}
       client: ${{ steps.filter.outputs.client }}
+      vscode: ${{ steps.filter.outputs.vscode }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v7
@@ -34,6 +35,8 @@ jobs:
               - 'pyproject.toml'
             client:
               - 'web/client/**'
+            vscode:
+              - 'vscode/**'
             ci:
               - '.github/**'
               - 'Makefile'
@@ -188,9 +191,10 @@ jobs:
 
   ui-style:
     needs: [changes]
-    if: false
-      # needs.changes.outputs.client == 'true' || needs.changes.outputs.ci ==
-      # 'true' || github.ref == 'refs/heads/main'
+    if:
+      needs.changes.outputs.client == 'true' || needs.changes.outputs.vscode ==
+      'true' || needs.changes.outputs.ci == 'true' || github.ref ==
+      'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -252,7 +256,17 @@ jobs:
       fail-fast: false
       matrix:
         engine:
-          [duckdb, postgres, mysql, mssql, trino, spark, clickhouse, risingwave, starrocks]
+          [
+            duckdb,
+            postgres,
+            mysql,
+            mssql,
+            trino,
+            spark,
+            clickhouse,
+            risingwave,
+            starrocks,
+          ]
     env:
       PYTEST_XDIST_AUTO_NUM_WORKERS: 2
       SQLMESH__DISABLE_ANONYMIZED_ANALYTICS: '1'
@@ -393,10 +407,13 @@ jobs:
           retention-days: 7
 
   test-vscode:
+    needs: changes
+    if:
+      needs.changes.outputs.vscode == 'true' || needs.changes.outputs.ci ==
+      'true' || github.ref == 'refs/heads/main'
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     runs-on: ubuntu-latest
-    if: false
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -457,7 +474,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbt-version: ['1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10', '1.11', '1.12']
+        dbt-version:
+          [
+            '1.3',
+            '1.4',
+            '1.5',
+            '1.6',
+            '1.7',
+            '1.8',
+            '1.9',
+            '1.10',
+            '1.11',
+            '1.12',
+          ]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python

--- a/vscode/extension/tests/fixtures.ts
+++ b/vscode/extension/tests/fixtures.ts
@@ -60,5 +60,5 @@ export const test = base.extend<
   ],
 })
 
-// Export expect and Page from Playwright for convenience
-export { expect, Page } from '@playwright/test'
+// Export expect and commonly used Playwright types for convenience
+export { expect, FrameLocator, Page } from '@playwright/test'

--- a/vscode/extension/tests/lineage_settings.spec.ts
+++ b/vscode/extension/tests/lineage_settings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import type { FrameLocator, Page } from '@playwright/test'
+import type { FrameLocator, Page } from './fixtures'
 import fs from 'fs-extra'
 import {
   openLineageView,

--- a/web/client/src/library/components/graph/ModelNode.tsx
+++ b/web/client/src/library/components/graph/ModelNode.tsx
@@ -198,7 +198,11 @@ export default function ModelNode({
       style={{
         width: '100%',
         ...(tagColor != null
-          ? { borderColor: tagColor, backgroundColor: tagColor, color: tagColor }
+          ? {
+              borderColor: tagColor,
+              backgroundColor: tagColor,
+              color: tagColor,
+            }
           : {}),
       }}
     >
@@ -246,7 +250,10 @@ export default function ModelNode({
         />
       </div>
       {showColumns && (
-        <div ref={columnsWrapperRef} style={{ height: '10rem', overflow: 'hidden' }}>
+        <div
+          ref={columnsWrapperRef}
+          style={{ height: '10rem', overflow: 'hidden' }}
+        >
           <ModelColumns
             className="nowheel rounded-b-lg bg-theme-lighter text-xs h-full"
             nodeId={id}

--- a/web/client/src/library/components/graph/help.ts
+++ b/web/client/src/library/components/graph/help.ts
@@ -175,7 +175,10 @@ function getNodeMap({
     const model = models.get(modelName)
     const tagsStr = model?.details?.tags
     const tags = tagsStr
-      ? tagsStr.split(',').map(t => t.trim()).filter(Boolean)
+      ? tagsStr
+          .split(',')
+          .map(t => t.trim())
+          .filter(Boolean)
       : undefined
     const node = createGraphNode(modelName, {
       label: model?.displayName ?? modelName,


### PR DESCRIPTION
## Description

Closes #6004.

`ui-style` and `test-vscode` were both pinned to `if: false`. This turns them back on and fixes everything that surfaced once they ran.

**1. Formatting / lint drift.** With `ui-style` off, `prettier --check .` and the per-package eslint runs stopped being enforced, so a few things drifted on `main`:

- `prettier --check .` fails on `.devcontainer/devcontainer.json`, `web/client/src/library/components/graph/help.ts`, `web/client/src/library/components/graph/ModelNode.tsx`, and `.github/workflows/pr.yaml` itself. All reformatted; the changes are whitespace only.
- `eslint src tests` fails in `vscode/extension`: `tests/lineage_settings.spec.ts` imports `FrameLocator` and `Page` directly from `@playwright/test`, which `no-restricted-imports` forbids for `tests/**/*.spec.ts`. Every other spec takes `Page` from `./fixtures`, so I followed that convention — re-exported `FrameLocator` from `tests/fixtures.ts` and imported both from there.

**2. Turning the jobs on**, following #5994:

- Added a `vscode` output to the `changes` job, filtering on `vscode/**`.
- `ui-style` now runs when `client`, `vscode` or `ci` changed, or on `main`.
- `test-vscode` gets the same treatment plus the `needs: changes` it was missing.

`test-vscode-e2e` is deliberately left disabled, per the note on the issue that its flakiness should be tracked separately.

### Note on the `pr.yaml` diff

Prettier reflows two matrix lists in `pr.yaml` that grew past the 80-column limit while the job was off — the `engine` list (StarRocks, #5832) and the `dbt-version` list (#6028, #5999). Those were already failing `prettier --check` on `main`, so they have to be fixed here for `fmt:check` to go green. I kept them in the CI commit so the formatting-only commit stays reviewable on its own.

## Test Plan

Ran both job commands locally against a clean `pnpm install`:

```
$ pnpm run lint     # the ui-style job
exit 0

$ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm run ci   # the test-vscode job
exit 0
```

`pnpm run ci` covers `vscode/bus` (`tsc --noEmit`), `vscode/extension` (`eslint` + `check-types` + `esbuild` + `vitest run` — 7 tests pass), and `web/common` (`syncpack` + `eslint` + `build`). Verified it leaves no modified files behind, which matters because `web/common`'s lint script runs with `--fix`.

I also confirmed against an unmodified `upstream/main` checkout that the two `pr.yaml` matrix reflows and the three other unformatted files are pre-existing, not something my edits introduced.

Local run was macOS / Node 24; CI uses Ubuntu / Node 22. Conveniently this PR touches both `.github/**` and `vscode/**`, so it should exercise `ui-style` and `test-vscode` on itself.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable) — no new tests; this is CI config plus formatting
- [x] All existing tests pass — ran the JS/TS suites via `pnpm run ci` (see Test Plan). No Python changed, so `make fast-test` is untouched by this PR and I did not run it
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
