### PR TITLE
fix(ci): minio image switch to chainguard

### DIFF
--- a/tests/core/engine_adapter/integration/docker/_common-hive.yaml
+++ b/tests/core/engine_adapter/integration/docker/_common-hive.yaml
@@ -12,22 +12,22 @@ services:
 
   # S3-style object storage
   minio:
-    image: 'minio/minio:RELEASE.2022-05-26T05-48-41Z'
+    image: 'cgr.dev/chainguard/minio:latest@sha256:039800e64ec7247d2fde7cff3697e964f6fe20b6d7d2c46aa7d82cc63355d512'
     ports:
       - '9000:9000'
       - '9001:9001'
     environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: minio123
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
     command: server /data --console-address ":9001"
 
   # Set up minio with default buckets / paths
   mc-job:
-    image: 'minio/mc:RELEASE.2022-05-09T04-08-26Z'
+    image: 'cgr.dev/chainguard/minio-client:latest-dev@sha256:fb635b967f5f32424391150dac4985cc1aea78fb0a1ce031c01952cf661a13ec'
     entrypoint: |
       /bin/bash -c "
       sleep 5;
-      /usr/bin/mc config --quiet host add myminio http://minio:9000 minio minio123;
+      /usr/bin/mc alias --quiet set myminio http://minio:9000 minio minio123;
       /usr/bin/mc mb --quiet myminio/trino/datalake;
       /usr/bin/mc mb --quiet myminio/trino/datalake_iceberg;
       /usr/bin/mc mb --quiet myminio/trino/datalake_delta;


### PR DESCRIPTION
## Description

Minio moved their images private on Docker Hub:
`mc-job Error pull access denied for minio/mc, repository does not exist or may require 'docker login': denied: requested access to the resource is denied`

Moving to chainguard's maintained fork version and pinning sha because you gotta pay for tags.

## Test Plan

CI success on Trino / Spark

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
