### PR TITLE
chore(lsp): limiting prettier formatting scope

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -30,6 +30,7 @@ docs
 examples
 posts
 .circleci
+.github/
 README.md
 mkdocs.yml
 .readthedocs.yaml

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   },
   "scripts": {
     "ci": "pnpm run lint && pnpm run -r ci",
-    "fmt": "prettier --write .",
-    "fmt:check": "prettier --check .",
+    "fmt": "prettier --write vscode web/client web/common",
+    "fmt:check": "prettier --check vscode web/client web/common",
     "lint": "pnpm run fmt:check && pnpm run -r lint",
     "lint:fix": "pnpm run fmt && pnpm run -r lint:fix"
   },


### PR DESCRIPTION
## Description

Currently the `prettier` format commands touch the entire repo, impacting our yaml files in our CI. Narrowing down the aliased commands to relevant directories and updating ignore file

## Test Plan

Test formatting commands and check

## Checklist

- [X] I have run `make style` and fixed any issues
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass (`make fast-test`)
- [X] My commits are signed off (`git commit -s`) per the [DCO](DCO)

<!-- See CONTRIBUTING.md for more details on the contribution process -->
