### PR TITLE
fix(vscode): stop the LSP restarting on unrelated configuration changes

### DIFF
--- a/vscode/extension/src/extension.ts
+++ b/vscode/extension/src/extension.ts
@@ -24,6 +24,8 @@ import {
   traceError,
 } from './utilities/common/log'
 import { onDidChangePythonInterpreter } from './utilities/common/python'
+import { requiresLspRestart } from './utilities/common/configurationChange'
+import { coalesceAsync } from './utilities/coalesceAsync'
 import { sleep } from './utilities/sleep'
 import { handleError } from './utilities/errors'
 
@@ -65,7 +67,16 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
   )
 
-  const restartLsp = async (invokedByUser = false): Promise<void> => {
+  /**
+   * Set when a restart was asked for explicitly, so that a user-invoked restart
+   * coalesced together with an automatic one is still treated as user-invoked.
+   */
+  let restartInvokedByUser = false
+
+  const runRestart = async (): Promise<void> => {
+    const invokedByUser = restartInvokedByUser
+    restartInvokedByUser = false
+
     if (!lspClient) {
       lspClient = new LSPClient()
     }
@@ -93,6 +104,18 @@ export async function activate(context: vscode.ExtensionContext) {
     }
     testControllerDisposable = setupTestController(lspClient)
     context.subscriptions.push(testControllerDisposable)
+  }
+
+  /**
+   * Restarts are serialized: a client disposing while the next one starts up
+   * leaves colliding command registrations and requests aimed at a disposed
+   * client, which is what surfaced as constant crashes.
+   */
+  const restartLspSerialized = coalesceAsync(runRestart)
+
+  const restartLsp = async (invokedByUser = false): Promise<void> => {
+    restartInvokedByUser = restartInvokedByUser || invokedByUser
+    await restartLspSerialized()
   }
 
   // commands needing the restart helper
@@ -191,7 +214,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     onDidChangePythonInterpreter(() => restartLsp()),
-    onDidChangeConfiguration(() => restartLsp()),
+    // Only restart for settings the server actually reads. This event fires for
+    // every setting in the editor, including ones written by other extensions.
+    onDidChangeConfiguration(event => {
+      if (requiresLspRestart(event)) {
+        void restartLsp()
+      }
+    }),
   )
 
   if (!lspClient.hasCompletionCapability()) {

--- a/vscode/extension/src/utilities/coalesceAsync.test.ts
+++ b/vscode/extension/src/utilities/coalesceAsync.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { coalesceAsync } from './coalesceAsync'
+
+/**
+ * Let pending microtasks run. A rerun is scheduled off the promise of the run
+ * that precedes it, so it starts a few hops after that run settles.
+ */
+const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+/** A task that only settles when the test releases it. */
+function deferredTask() {
+  let release: (() => void) | undefined
+  let rejectWith: ((error: Error) => void) | undefined
+  let calls = 0
+
+  const run = () => {
+    calls += 1
+    return new Promise<void>((resolve, reject) => {
+      release = resolve
+      rejectWith = reject
+    })
+  }
+
+  return {
+    run,
+    get calls() {
+      return calls
+    },
+    release: () => release?.(),
+    reject: (error: Error) => rejectWith?.(error),
+  }
+}
+
+describe('coalesceAsync', () => {
+  it('runs the task immediately when idle', async () => {
+    const task = deferredTask()
+    const run = coalesceAsync(task.run)
+
+    const first = run()
+    expect(task.calls).toBe(1)
+
+    task.release()
+    await first
+  })
+
+  // A burst of triggers used to start a restart per event, which left clients
+  // disposing and starting concurrently. See #5642.
+  it('collapses every call made while running into a single rerun', async () => {
+    const task = deferredTask()
+    const run = coalesceAsync(task.run)
+
+    const first = run()
+    expect(task.calls).toBe(1)
+
+    const queued = [run(), run(), run(), run()]
+    expect(task.calls).toBe(1)
+
+    task.release()
+    await first
+    await flush()
+
+    // Exactly one rerun is scheduled, no matter how many calls arrived.
+    expect(task.calls).toBe(2)
+
+    task.release()
+    await Promise.all(queued)
+    await flush()
+    expect(task.calls).toBe(2)
+  })
+
+  it('runs again for calls made after the previous run finished', async () => {
+    const task = deferredTask()
+    const run = coalesceAsync(task.run)
+
+    const first = run()
+    task.release()
+    await first
+    expect(task.calls).toBe(1)
+
+    const second = run()
+    expect(task.calls).toBe(2)
+    task.release()
+    await second
+  })
+
+  it('resolves the callers that were coalesced together', async () => {
+    const task = deferredTask()
+    const run = coalesceAsync(task.run)
+
+    const first = run()
+    const queued = [run(), run()]
+
+    task.release()
+    await first
+    // The rerun has to be in flight before it can be released.
+    await flush()
+    task.release()
+
+    await expect(Promise.all(queued)).resolves.toEqual([undefined, undefined])
+  })
+
+  it('surfaces a failure without wedging later calls', async () => {
+    const task = deferredTask()
+    const run = coalesceAsync(task.run)
+
+    const first = run()
+    task.reject(new Error('restart failed'))
+    await expect(first).rejects.toThrow('restart failed')
+
+    const second = run()
+    expect(task.calls).toBe(2)
+    task.release()
+    await second
+  })
+})

--- a/vscode/extension/src/utilities/coalesceAsync.ts
+++ b/vscode/extension/src/utilities/coalesceAsync.ts
@@ -1,0 +1,49 @@
+/**
+ * Serialize an async task so it never overlaps with itself, collapsing any
+ * calls that arrive while it is running into a single rerun.
+ *
+ * Restarting the language server means stopping a client and starting another.
+ * Letting two of those interleave leaves commands registered by the outgoing
+ * client colliding with the incoming one, and leaves requests addressed to a
+ * client that has already been disposed. Queueing one run per trigger would
+ * only spread the same problem out over time, so queued triggers collapse into
+ * one rerun: all the caller wants is for the task to have run after its
+ * request, not for it to run once per request.
+ *
+ * @param task The task to serialize.
+ * @returns A function that resolves once the task has run for that call.
+ */
+export function coalesceAsync(task: () => Promise<void>): () => Promise<void> {
+  let running: Promise<void> | undefined
+  let queued: Promise<void> | undefined
+
+  const start = async (): Promise<void> => {
+    try {
+      await task()
+    } finally {
+      running = undefined
+    }
+  }
+
+  return (): Promise<void> => {
+    if (!running) {
+      running = start()
+      return running
+    }
+
+    // A rerun is already scheduled, so this call is satisfied by that one.
+    if (!queued) {
+      queued = running
+        // A failed run must not stop the rerun that was asked for; the caller
+        // waiting on the failed run is the one that sees the error.
+        .catch(() => undefined)
+        .then(() => {
+          queued = undefined
+          running = start()
+          return running
+        })
+    }
+
+    return queued
+  }
+}

--- a/vscode/extension/src/utilities/common/configurationChange.test.ts
+++ b/vscode/extension/src/utilities/common/configurationChange.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { requiresLspRestart } from './configurationChange'
+
+/**
+ * Build a stand-in for `vscode.ConfigurationChangeEvent` from the settings that
+ * changed. VS Code reports a section as affected when the changed key is the
+ * section itself or sits underneath it.
+ */
+const changed = (...keys: string[]) => ({
+  affectsConfiguration: (section: string) =>
+    keys.some(key => key === section || key.startsWith(`${section}.`)),
+})
+
+describe('requiresLspRestart', () => {
+  it('restarts when a sqlmesh setting changes', () => {
+    expect(requiresLspRestart(changed('sqlmesh.projectPaths'))).toBe(true)
+    expect(requiresLspRestart(changed('sqlmesh.lspEntrypoint'))).toBe(true)
+  })
+
+  it('restarts when the python interpreter changes', () => {
+    expect(requiresLspRestart(changed('python.defaultInterpreterPath'))).toBe(
+      true,
+    )
+  })
+
+  // The LSP used to restart on every configuration change in the editor, so
+  // anything that wrote a setting took the extension down with it. See #5920.
+  it('ignores settings the language server does not read', () => {
+    expect(requiresLspRestart(changed('editor.fontSize'))).toBe(false)
+    expect(requiresLspRestart(changed('workbench.colorTheme'))).toBe(false)
+    expect(requiresLspRestart(changed('files.autoSave'))).toBe(false)
+  })
+
+  // Running any python command in a VS Code terminal makes the Python
+  // extension touch its own terminal settings, which is what made the
+  // extension crash whenever sqlmesh was run in the terminal. See #5642.
+  it('ignores python settings unrelated to the interpreter', () => {
+    expect(
+      requiresLspRestart(changed('python.terminal.activateEnvironment')),
+    ).toBe(false)
+    expect(
+      requiresLspRestart(changed('python.analysis.typeCheckingMode')),
+    ).toBe(false)
+    expect(requiresLspRestart(changed('terminal.integrated.env.linux'))).toBe(
+      false,
+    )
+  })
+
+  it('does not restart when nothing relevant changed', () => {
+    expect(requiresLspRestart(changed())).toBe(false)
+  })
+
+  it('restarts when a relevant setting changes alongside irrelevant ones', () => {
+    expect(
+      requiresLspRestart(changed('editor.fontSize', 'sqlmesh.projectPaths')),
+    ).toBe(true)
+  })
+})

--- a/vscode/extension/src/utilities/common/configurationChange.ts
+++ b/vscode/extension/src/utilities/common/configurationChange.ts
@@ -1,0 +1,33 @@
+/**
+ * Configuration sections the language server reads, so a change to any of them
+ * needs the server restarted to take effect.
+ *
+ * `sqlmesh` covers `sqlmesh.projectPaths` and `sqlmesh.lspEntrypoint`, both of
+ * which decide how the server is launched. The interpreter path matters because
+ * the server runs inside that interpreter.
+ */
+export const RESTART_CONFIGURATION_SECTIONS = [
+  'sqlmesh',
+  'python.defaultInterpreterPath',
+]
+
+/**
+ * The part of `vscode.ConfigurationChangeEvent` this module needs. Declared
+ * structurally so the check stays unit testable without the VS Code runtime.
+ */
+export interface ConfigurationChange {
+  affectsConfiguration(section: string): boolean
+}
+
+/**
+ * Whether a configuration change affects a setting the language server reads.
+ *
+ * `workspace.onDidChangeConfiguration` fires for every setting in the editor,
+ * including ones written by other extensions, so the event has to be filtered
+ * before it triggers a restart.
+ */
+export function requiresLspRestart(event: ConfigurationChange): boolean {
+  return RESTART_CONFIGURATION_SECTIONS.some(section =>
+    event.affectsConfiguration(section),
+  )
+}


### PR DESCRIPTION
## Description

Fixes #5920. Fixes #5642.

Both issues are the same bug: the extension restarted the language server far more often than it needed to, and let those restarts overlap. That produced the errors reported in both — `Client got disposed and can't be restarted`, and a stream of `command 'sqlmesh.external_model_update_columns' already exists`.

### 1. The LSP restarted on every configuration change in the editor

`extension.ts` subscribed to `workspace.onDidChangeConfiguration` and restarted unconditionally:

```ts
onDidChangeConfiguration(() => restartLsp()),
```

That event fires for **any** setting in the editor, including settings written by other extensions. It now restarts only when a section the server actually reads is affected — `sqlmesh` (which covers `projectPaths` and `lspEntrypoint`, both of which decide how the server is launched) or `python.defaultInterpreterPath` (the server runs inside that interpreter).

This accounts for the observations in #5642 that were otherwise hard to explain:

- Running any python command in a VS Code terminal killed the extension — the Python extension touches its own settings in response, and that alone triggered a restart.
- Running a **copy** of the same interpreter from a different path did *not* reproduce it — an unrecognised path makes the Python extension do nothing.
- `su`, `uvx`, a subshell or a notebook did not reproduce it either — none of those go through VS Code's shell integration, so no setting is written.

### 2. Restarts could overlap

`LSPClient.restart()` is `stop()` then `start()`. With a burst of triggers, several of those interleave: the outgoing client's command registrations collide with the incoming client's, and in-flight requests are aimed at a client that has already been disposed — exactly the two error messages in the reports.

Restarts are now serialized. Triggers arriving mid-restart collapse into a single rerun rather than queueing one restart each, since all a trigger needs is for a restart to have happened after it. An explicit restart (`sqlmesh.restart`, sign-in, format) is never downgraded to an automatic one when coalesced with one.

### A related finding, deliberately not changed here

`initializePython()` in `utilities/common/python.ts` **has no call sites**, so `onDidChangePythonInterpreterEvent` is never fired and the `onDidChangePythonInterpreter(() => restartLsp())` subscription in `extension.ts` is currently inert. Two consequences worth flagging:

- Changing the Python interpreter does not currently restart the server, so it keeps running under the old one.
- If that function is ever wired up as-is, it re-fires on every `onDidChangeActiveEnvironmentPath` **without comparing against the path it last saw**, which would reintroduce a restart storm.

I left it alone rather than widen this PR — happy to follow up if you'd like it wired up with a path comparison, or removed.

## Test Plan

New unit tests, both in modules kept free of `vscode` imports so `vitest` can cover them in the `test-vscode` stage:

- `configurationChange.test.ts` — restarts for `sqlmesh.projectPaths`, `sqlmesh.lspEntrypoint` and `python.defaultInterpreterPath`; does **not** restart for `editor.fontSize`, `workbench.colorTheme`, `files.autoSave`, `python.terminal.activateEnvironment`, `python.analysis.typeCheckingMode` or `terminal.integrated.env.linux`. The last three are the regression tests for the terminal scenario in #5642.
- `coalesceAsync.test.ts` — runs immediately when idle; four calls during a run collapse into exactly one rerun; every coalesced caller resolves; a later call still runs after a failure.

Ran both CI job commands locally:

```
$ pnpm run lint                                    # ui-style
exit 0

$ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm run ci   # test-vscode
exit 0     # 18 unit tests pass (7 before this PR)
```

I have not reproduced the crash end to end in a live VS Code session — `test-vscode-e2e` is still disabled, and the trigger needs a real Python extension writing settings. The causal chain is established from the code path plus the reporter's process-of-elimination in #5642, and the unit tests pin the specific settings that must and must not cause a restart. Worth a sanity check from someone who can reproduce the original crash.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass — ran the JS/TS suites via `pnpm run ci`; no Python changed, so `make fast-test` is unaffected by this PR
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)

cc @cmgoffena13 — picking this up per your note on #6054. Checked both issues for assignees and linked PRs beforehand; both were unassigned with nothing linked.
