### PR TITLE
perf: avoid full snapshot mapping in _resolve_table/_resolve_tables

### DIFF
--- a/sqlmesh/core/renderer.py
+++ b/sqlmesh/core/renderer.py
@@ -330,12 +330,27 @@ class BaseExpressionRenderer:
         table_mapping: t.Optional[t.Dict[str, str]] = None,
         deployability_index: t.Optional[DeployabilityIndex] = None,
     ) -> exp.Table:
+        table_mapping = table_mapping or {}
+        if isinstance(table_name, str):
+            # table_name arrives here already normalized to a model FQN (see the `resolve_table`
+            # closure below and the `this_model` call site), the same key format `snapshots` and
+            # `table_mapping` use. Only the one relevant snapshot needs mapping, not the whole
+            # environment - building the full mapping made this call O(N) in the number of
+            # snapshots in the environment for every table resolved.
+            snapshot = snapshots.get(table_name) if snapshots else None
+            mapping = {
+                **self._to_table_mapping([snapshot] if snapshot else [], deployability_index),
+                **({table_name: table_mapping[table_name]} if table_name in table_mapping else {}),
+            }
+        else:
+            mapping = {
+                **self._to_table_mapping((snapshots or {}).values(), deployability_index),
+                **table_mapping,
+            }
+
         table = exp.replace_tables(
             t.cast(exp.Table, exp.maybe_parse(table_name, into=exp.Table, dialect=self._dialect)),
-            {
-                **self._to_table_mapping((snapshots or {}).values(), deployability_index),
-                **(table_mapping or {}),
-            },
+            mapping,
             dialect=self._dialect,
             copy=False,
         )
@@ -365,10 +380,6 @@ class BaseExpressionRenderer:
         with self._normalize_and_quote(expression) as expression:
             snapshots = snapshots or {}
             table_mapping = table_mapping or {}
-            mapping = {
-                **self._to_table_mapping(snapshots.values(), deployability_index),
-                **table_mapping,
-            }
             expand = set(expand) | {
                 name for name, snapshot in snapshots.items() if snapshot.is_embedded
             }
@@ -410,10 +421,22 @@ class BaseExpressionRenderer:
 
                 expression = expression.transform(_expand, copy=False)  # type: ignore
 
-            if mapping:
-                expression = exp.replace_tables(
-                    expression, mapping, dialect=self._dialect, copy=False
-                )
+            # Building the full snapshot -> table-name mapping and normalizing it in
+            # exp.replace_tables is O(N) in the number of snapshots in the environment; skip it
+            # entirely for expressions that don't reference any table at all (e.g. session/
+            # virtual properties), since there's nothing for the mapping to replace.
+            if expression.find(exp.Table):
+                # mypy loses the `snapshots`/`table_mapping` narrowing above because they're
+                # captured by the `_expand` closure defined earlier in this block.
+                assert snapshots is not None and table_mapping is not None
+                mapping = {
+                    **self._to_table_mapping(snapshots.values(), deployability_index),
+                    **table_mapping,
+                }
+                if mapping:
+                    expression = exp.replace_tables(
+                        expression, mapping, dialect=self._dialect, copy=False
+                    )
 
             return expression
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -9748,6 +9748,122 @@ def test_resolve_table(make_snapshot: t.Callable):
         assert post_statements[0].sql() == f'"main"."sqlmesh__schema"."schema__parent__{version}"'
 
 
+def test_resolve_table_large_environment(make_snapshot: t.Callable, mocker: MockerFixture):
+    """`_resolve_table` should only build a mapping for the one table being resolved, not the
+    entire environment (https://github.com/SQLMesh/sqlmesh/issues/6017)."""
+
+    @macro()
+    def resolve_named(evaluator, name):
+        return evaluator.resolve_table(name.name)
+
+    target = load_sql_based_model(d.parse("MODEL (name target); SELECT 1 AS c"))
+    target_snapshot = make_snapshot(target)
+    target_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+
+    snapshots = {'"target"': target_snapshot}
+    for i in range(50):
+        other = load_sql_based_model(d.parse(f"MODEL (name other_{i}); SELECT 1 AS c"))
+        other_snapshot = make_snapshot(other)
+        other_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+        snapshots[f'"other_{i}"'] = other_snapshot
+
+    child = load_sql_based_model(
+        d.parse(
+            """
+            MODEL (name child);
+            SELECT c FROM target;
+            @resolve_named('target')
+            """
+        )
+    )
+
+    spy = mocker.spy(exp, "replace_tables")
+
+    post_statements = child.render_post_statements(snapshots=snapshots)
+    assert len(post_statements) == 1
+    assert post_statements[0].sql() == f'"sqlmesh__default"."target__{target_snapshot.version}"'
+
+    # every replace_tables call made while resolving the single `target` reference should only
+    # ever see that one mapping entry, not all 51 snapshots in the environment
+    for call in spy.call_args_list:
+        assert len(call.args[1]) <= 1
+
+    # an explicit table_mapping entry takes precedence over the snapshot-derived one (rendered
+    # via a separate model instance so the statement-render cache doesn't return the earlier result)
+    child_for_override = load_sql_based_model(
+        d.parse(
+            """
+            MODEL (name child_override);
+            SELECT c FROM target;
+            @resolve_named('target')
+            """
+        )
+    )
+    override = child_for_override.render_post_statements(
+        snapshots=snapshots, table_mapping={'"target"': "overridden_table"}
+    )
+    assert override[0].sql() == '"overridden_table"'
+
+    # a name absent from both snapshots and table_mapping resolves unchanged
+    unmapped = load_sql_based_model(
+        d.parse(
+            """
+            MODEL (name unmapped_child);
+            SELECT 1 AS c;
+            @resolve_named('does_not_exist')
+            """
+        )
+    )
+    unmapped_result = unmapped.render_post_statements(snapshots=snapshots)
+    assert unmapped_result[0].sql() == '"does_not_exist"'
+
+
+def test_render_virtual_properties_skips_mapping_without_table_refs(
+    make_snapshot: t.Callable, mocker: MockerFixture
+):
+    """Rendering a property expression with no table references shouldn't build the full
+    snapshot -> table-name mapping at all (https://github.com/SQLMesh/sqlmesh/issues/6017)."""
+    import sqlmesh.core.snapshot as snapshot_module
+
+    model = load_sql_based_model(
+        d.parse(
+            """
+            MODEL (
+                name test_schema.test_model,
+                virtual_properties (
+                    labels = [('team', 'data')]
+                ),
+                session_properties (
+                    "spark.executor.memory" = '1G'
+                ),
+            );
+            SELECT a FROM tbl;
+            """
+        )
+    )
+
+    snapshots = {}
+    for i in range(50):
+        other = load_sql_based_model(d.parse(f"MODEL (name other_{i}); SELECT 1 AS c"))
+        other_snapshot = make_snapshot(other)
+        other_snapshot.categorize_as(SnapshotChangeCategory.BREAKING)
+        snapshots[f'"other_{i}"'] = other_snapshot
+
+    to_table_mapping_spy = mocker.spy(snapshot_module, "to_table_mapping")
+
+    assert model.render_virtual_properties(snapshots=snapshots) == {
+        "labels": exp.maybe_parse("[('team', 'data')]")
+    }
+    assert model.render_session_properties(snapshots=snapshots) == {
+        "spark.executor.memory": "1G",
+    }
+
+    # `this_model` resolution may still make a narrow, single-snapshot (or empty) call, but the
+    # full N-snapshot mapping build in `_resolve_tables` must never fire for a table-less property
+    for call in to_table_mapping_spy.call_args_list:
+        assert len(call.args[0]) <= 1
+
+
 def test_cluster_with_complex_expression():
     expressions = d.parse(
         """


### PR DESCRIPTION
## Description

Resolving one table during virtual-layer updates previously built and normalized a mapping for every snapshot. `_resolve_table` now maps only the matching snapshot on an exact lookup, retaining the full-mapping fallback for dialect-dependent name mismatches. `_resolve_tables` skips snapshot scans and expansion setup when an expression contains no table reference.

During promotion, each target model can receive the broader snapshot context because its expressions and macros may reference other models. Property values go through the same expression renderer as SQL statements. Previously, even a literal virtual property such as `description = 'Customer orders'` triggered construction of the full snapshot mapping when snapshots were supplied, despite containing no table reference.

This work repeats per rendered property or statement, not just once per plan. For illustration, promoting 1,000 models with three literal virtual properties each and a 1,000-snapshot context would cause 3,000 mapping builds, each visiting 1,000 snapshots. This is a count of avoidable work for that hypothetical workload, not a measured benchmark or timing claim. Empty property collections produce no calls, and calls without snapshots, overrides, or expansion already returned early.

The change targets that unnecessary setup. Expressions containing table references still use the broader mapping, while single-table resolution narrows the snapshot lookup when an exact match is available.

Explicit `table_mapping` entries retain their dialect-aware matching and precedence, including when an exact snapshot match exists or a later equivalent override follows an exact-key override. The fast path avoids scanning unrelated snapshots; processing explicit overrides remains proportional to the size of that mapping.

Fixes #6017.

## Test Plan

- Regression coverage for exact snapshot matches with equivalent override keys, including later-override precedence through a rendered macro.
- Coverage checks snapshot scan counts, cross-dialect fallbacks, mapping without snapshots, expression inputs, expansion, table-less properties, and deployability. The cross-dialect test uses explicit normalization settings to avoid dependence on global dialect state or cached values.
- The previously failing dbt/model test sequence passes (2 tests); focused renderer coverage passes (13 tests).
- `make style`: passed (Ruff, formatting, mypy, migration validation).
- Fast-test coverage: 2,636 passed / 4 skipped in the main phase; all isolated tests passed, with the two forking tests rerun separately after a DuckDB cleanup hang. Registry and dialect phases passed (1 and 161 tests). The final comment-only edit leaves the Python AST unchanged.
- GitHub CI on `07e2ddf4`: DCO/Commits Check passed; the full CI run is still in progress.

## Checklist

- [x] I have run `make style` and fixed any issues
- [x] I have added tests for my changes (if applicable)
- [x] All existing tests pass (`make fast-test`)
- [x] My commits are signed off (`git commit -s`) per the [DCO](DCO)
